### PR TITLE
Issue #128: Integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ Finally, update `[PROJECT_ROOT]\.git\info\exclude` to ignore the symlink locally
 
 ## Testing ##
 
-Testing is done with the [Robolectric framework.](http://robolectric.org/) To run tests simply run `gradlew testDebug`. Code coverage reports can be generated via [JaCoCo.](http://www.eclemma.org/jacoco/) To generate them locally run `gradlew jacocoTestReport`.
+This project has both unit testing and integration testing, maintained and run separately.
+
+Unit testing is done with the [Robolectric framework](http://robolectric.org/). To run unit tests simply run `gradlew testDebug`. Code coverage reports can be generated via [JaCoCo.](http://www.eclemma.org/jacoco/) To generate them locally run `gradlew jacocoTestReport`.
+
+Integration testing is done with the [Android testing framework](http://developer.android.com/tools/testing/testing_android.html). To run integration tests run `gradlew connectedAndroidTest`.
+
+Add new unit tests to `androidTest/java/org.wordpress.android.editor` and integration tests to `androidTest/java/org.wordpress.android.editor/integration`.
 
 ## LICENSE ##
 

--- a/WordPressEditor/build.gradle
+++ b/WordPressEditor/build.gradle
@@ -36,6 +36,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    // Avoid 'duplicate files during packaging of APK' errors
+    packagingOptions {
+        exclude 'LICENSE.txt'
+        exclude 'META-INF/LICENSE.txt'
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/NOTICE'
+        exclude 'META-INF/NOTICE.txt'
+    }
 }
 
 dependencies {
@@ -45,13 +54,13 @@ dependencies {
     compile 'org.wordpress:utils:1.6.0'
 
     // Test libraries
-    testCompile 'junit:junit:4.10'
+    testCompile 'junit:junit:4.11'
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'org.robolectric:robolectric:2.4'
 
     // Workaround for IDE bug
     // http://stackoverflow.com/questions/22246183/android-studio-doesnt-recognize-espresso-classes
-    provided 'junit:junit:4.10'
+    provided 'junit:junit:4.11'
     provided 'org.mockito:mockito-core:1.10.19'
     provided 'org.robolectric:robolectric:2.4'
 }
@@ -119,6 +128,7 @@ uploadArchives {
 robolectric {
     include '**/*Test.class'
     exclude '**/ApplicationTest.class'
+    exclude '**/integration/**'
 }
 
 jacoco {

--- a/WordPressEditor/src/androidTest/AndroidManifest.xml
+++ b/WordPressEditor/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.wordpress.android.editor" >
+    <application>
+        <activity android:name=".integration.ExampleEditorActivity" android:exported="false" />
+    </application>>
+</manifest>

--- a/WordPressEditor/src/androidTest/AndroidManifest.xml
+++ b/WordPressEditor/src/androidTest/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.wordpress.android.editor" >
     <application>
+        <activity android:name=".integration.MockActivity" android:exported="false" />
         <activity android:name=".integration.MockEditorActivity" android:exported="false" />
     </application>>
 </manifest>

--- a/WordPressEditor/src/androidTest/AndroidManifest.xml
+++ b/WordPressEditor/src/androidTest/AndroidManifest.xml
@@ -2,6 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.wordpress.android.editor" >
     <application>
-        <activity android:name=".integration.ExampleEditorActivity" android:exported="false" />
+        <activity android:name=".integration.MockEditorActivity" android:exported="false" />
     </application>>
 </manifest>

--- a/WordPressEditor/src/androidTest/java/org/wordpress/android/editor/JsCallbackReceiverTest.java
+++ b/WordPressEditor/src/androidTest/java/org/wordpress/android/editor/JsCallbackReceiverTest.java
@@ -19,7 +19,7 @@ import static org.robolectric.shadows.ShadowLog.LogItem;
 
 @Config(emulateSdk = 18)
 @RunWith(RobolectricTestRunner.class)
-public class JsCallbackHandlerTest {
+public class JsCallbackReceiverTest {
     private final static String EDITOR_LOG_TAG = "WordPress-" + AppLog.T.EDITOR.toString();
 
     private JsCallbackReceiver mJsCallbackReceiver;

--- a/WordPressEditor/src/androidTest/java/org/wordpress/android/editor/TestingUtils.java
+++ b/WordPressEditor/src/androidTest/java/org/wordpress/android/editor/TestingUtils.java
@@ -1,0 +1,14 @@
+package org.wordpress.android.editor;
+
+import org.wordpress.android.util.AppLog;
+
+public class TestingUtils {
+
+    static public void waitFor(long milliseconds) {
+        try {
+            Thread.sleep(milliseconds);
+        } catch(InterruptedException e) {
+            AppLog.e(AppLog.T.EDITOR, "Thread interrupted");
+        }
+    }
+}

--- a/WordPressEditor/src/androidTest/java/org/wordpress/android/editor/integration/EditorFragmentForTests.java
+++ b/WordPressEditor/src/androidTest/java/org/wordpress/android/editor/integration/EditorFragmentForTests.java
@@ -1,0 +1,45 @@
+package org.wordpress.android.editor.integration;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.wordpress.android.editor.EditorFragment;
+import org.wordpress.android.editor.EditorWebViewAbstract;
+import org.wordpress.android.editor.R;
+
+import java.util.Map;
+
+public class EditorFragmentForTests extends EditorFragment {
+    protected EditorWebViewAbstract mWebView;
+
+    protected boolean mInitCalled = false;
+    protected boolean mDomLoaded = false;
+    protected boolean mOnSelectionStyleChangedCalled = false;
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View view = super.onCreateView(inflater, container, savedInstanceState);
+        mWebView = (EditorWebViewAbstract) view.findViewById(R.id.webview);
+        return view;
+    }
+
+    @Override
+    protected void initJsEditor() {
+        super.initJsEditor();
+        mInitCalled = true;
+    }
+
+    @Override
+    public void onDomLoaded() {
+        super.onDomLoaded();
+        mDomLoaded = true;
+    }
+
+    @Override
+    public void onSelectionStyleChanged(final Map<String, Boolean> changeMap) {
+        super.onSelectionStyleChanged(changeMap);
+        mOnSelectionStyleChangedCalled = true;
+    }
+}

--- a/WordPressEditor/src/androidTest/java/org/wordpress/android/editor/integration/EditorFragmentTest.java
+++ b/WordPressEditor/src/androidTest/java/org/wordpress/android/editor/integration/EditorFragmentTest.java
@@ -1,0 +1,64 @@
+package org.wordpress.android.editor.integration;
+
+import android.app.Activity;
+import android.test.ActivityInstrumentationTestCase2;
+import android.widget.ToggleButton;
+
+import org.wordpress.android.editor.R;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.wordpress.android.editor.TestingUtils.waitFor;
+
+public class EditorFragmentTest extends ActivityInstrumentationTestCase2<MockEditorActivity> {
+    Activity mActivity;
+    EditorFragmentForTests mFragment;
+
+    public EditorFragmentTest() {
+        super(MockEditorActivity.class);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        mActivity = getActivity();
+        mFragment = (EditorFragmentForTests) mActivity.getFragmentManager().findFragmentByTag("editorFragment");
+    }
+
+    public void testDomLoadedCallbackReceived() {
+        // initJsEditor() should have been called on setup
+        assertTrue(mFragment.mInitCalled);
+
+        long start = System.currentTimeMillis();
+        while(!mFragment.mDomLoaded) {
+            waitFor(10);
+            if (System.currentTimeMillis() - start > 5000) {
+                throw(new RuntimeException("Callback wait timed out"));
+            }
+        }
+
+        // The JS editor should have sent out a callback when the DOM loaded, triggering onDomLoaded()
+        assertTrue(mFragment.mDomLoaded);
+    }
+
+    public void testFormatBarToggledOnSelectedFieldChanged() {
+        Map<String, String> selectionArgs = new HashMap<>();
+
+        selectionArgs.put("id", "zss_field_title");
+        mFragment.onSelectionChanged(selectionArgs);
+
+        waitFor(100);
+
+        ToggleButton boldButton = (ToggleButton) mFragment.getView().findViewById(R.id.format_bar_button_bold);
+        assertFalse(boldButton.isEnabled());
+
+        selectionArgs.clear();
+        selectionArgs.put("id", "zss_field_content");
+        mFragment.onSelectionChanged(selectionArgs);
+
+        waitFor(100);
+
+        assertTrue(boldButton.isEnabled());
+    }
+}

--- a/WordPressEditor/src/androidTest/java/org/wordpress/android/editor/integration/EditorFragmentTest.java
+++ b/WordPressEditor/src/androidTest/java/org/wordpress/android/editor/integration/EditorFragmentTest.java
@@ -2,6 +2,7 @@ package org.wordpress.android.editor.integration;
 
 import android.app.Activity;
 import android.test.ActivityInstrumentationTestCase2;
+import android.view.View;
 import android.widget.ToggleButton;
 
 import org.wordpress.android.editor.R;
@@ -12,8 +13,8 @@ import java.util.Map;
 import static org.wordpress.android.editor.TestingUtils.waitFor;
 
 public class EditorFragmentTest extends ActivityInstrumentationTestCase2<MockEditorActivity> {
-    Activity mActivity;
-    EditorFragmentForTests mFragment;
+    private Activity mActivity;
+    private EditorFragmentForTests mFragment;
 
     public EditorFragmentTest() {
         super(MockEditorActivity.class);
@@ -50,8 +51,37 @@ public class EditorFragmentTest extends ActivityInstrumentationTestCase2<MockEdi
 
         waitFor(100);
 
-        ToggleButton boldButton = (ToggleButton) mFragment.getView().findViewById(R.id.format_bar_button_bold);
+        View view = mFragment.getView();
+
+        if (view == null) {
+            throw(new IllegalStateException("Fragment view is empty"));
+        }
+
+        // The formatting buttons should be disabled while the title field is selected
+        ToggleButton mediaButton = (ToggleButton) view.findViewById(R.id.format_bar_button_media);
+        ToggleButton boldButton = (ToggleButton) view.findViewById(R.id.format_bar_button_bold);
+        ToggleButton italicButton = (ToggleButton) view.findViewById(R.id.format_bar_button_italic);
+        ToggleButton quoteButton = (ToggleButton) view.findViewById(R.id.format_bar_button_quote);
+        ToggleButton ulButton = (ToggleButton) view.findViewById(R.id.format_bar_button_ul);
+        ToggleButton olButton = (ToggleButton) view.findViewById(R.id.format_bar_button_ol);
+        ToggleButton linkButton = (ToggleButton) view.findViewById(R.id.format_bar_button_link);
+        ToggleButton strikethroughButton = (ToggleButton) view.findViewById(R.id.format_bar_button_strikethrough);
+
+        assertFalse(mediaButton.isEnabled());
         assertFalse(boldButton.isEnabled());
+        assertFalse(italicButton.isEnabled());
+        assertFalse(quoteButton.isEnabled());
+        assertFalse(ulButton.isEnabled());
+        assertFalse(olButton.isEnabled());
+        assertFalse(linkButton.isEnabled());
+
+        if (strikethroughButton != null) {
+            assertFalse(strikethroughButton.isEnabled());
+        }
+
+        // The HTML button should always be enabled
+        ToggleButton htmlButton = (ToggleButton) view.findViewById(R.id.format_bar_button_html);
+        assertTrue(htmlButton.isEnabled());
 
         selectionArgs.clear();
         selectionArgs.put("id", "zss_field_content");
@@ -59,6 +89,20 @@ public class EditorFragmentTest extends ActivityInstrumentationTestCase2<MockEdi
 
         waitFor(100);
 
+        // The formatting buttons should be enabled while the content field is selected
+        assertTrue(mediaButton.isEnabled());
         assertTrue(boldButton.isEnabled());
+        assertTrue(italicButton.isEnabled());
+        assertTrue(quoteButton.isEnabled());
+        assertTrue(ulButton.isEnabled());
+        assertTrue(olButton.isEnabled());
+        assertTrue(linkButton.isEnabled());
+
+        if (strikethroughButton != null) {
+            assertTrue(strikethroughButton.isEnabled());
+        }
+
+        // The HTML button should always be enabled
+        assertTrue(htmlButton.isEnabled());
     }
 }

--- a/WordPressEditor/src/androidTest/java/org/wordpress/android/editor/integration/MockActivity.java
+++ b/WordPressEditor/src/androidTest/java/org/wordpress/android/editor/integration/MockActivity.java
@@ -1,0 +1,7 @@
+package org.wordpress.android.editor.integration;
+
+import android.app.Activity;
+
+public class MockActivity extends Activity {
+
+}

--- a/WordPressEditor/src/androidTest/java/org/wordpress/android/editor/integration/MockEditorActivity.java
+++ b/WordPressEditor/src/androidTest/java/org/wordpress/android/editor/integration/MockEditorActivity.java
@@ -1,0 +1,53 @@
+package org.wordpress.android.editor.integration;
+
+import android.app.FragmentManager;
+import android.app.FragmentTransaction;
+import android.os.Bundle;
+import android.support.v4.app.FragmentActivity;
+import android.widget.LinearLayout;
+
+import org.wordpress.android.editor.EditorFragment;
+import org.wordpress.android.editor.EditorFragmentAbstract;
+import org.wordpress.android.util.helpers.MediaFile;
+
+public class MockEditorActivity extends FragmentActivity implements EditorFragmentAbstract.EditorFragmentListener {
+    public static final int LAYOUT_ID = 999;
+
+    @SuppressWarnings("ResourceType")
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        LinearLayout linearLayout = new LinearLayout(this);
+        linearLayout.setId(LAYOUT_ID);
+        setContentView(linearLayout);
+
+        FragmentManager fragmentManager = getFragmentManager();
+        FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+
+        EditorFragment fragment = new EditorFragmentForTests();
+        fragmentTransaction.add(linearLayout.getId(), fragment, "editorFragment");
+        fragmentTransaction.commit();
+    }
+
+    @Override
+    public void onEditorFragmentInitialized() {
+
+    }
+
+    @Override
+    public void onSettingsClicked() {
+
+    }
+
+    @Override
+    public void onAddMediaClicked() {
+
+    }
+
+    @Override
+    public void saveMediaFile(MediaFile mediaFile) {
+
+    }
+}
+

--- a/WordPressEditor/src/androidTest/java/org/wordpress/android/editor/integration/ZssEditorTest.java
+++ b/WordPressEditor/src/androidTest/java/org/wordpress/android/editor/integration/ZssEditorTest.java
@@ -1,0 +1,107 @@
+package org.wordpress.android.editor.integration;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.app.Instrumentation;
+import android.test.ActivityInstrumentationTestCase2;
+import android.webkit.JavascriptInterface;
+
+import org.wordpress.android.editor.EditorWebView;
+import org.wordpress.android.editor.EditorWebViewAbstract;
+import org.wordpress.android.editor.Utils;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests for the <code>ZSSEditor</code> inside an <code>EditorWebViewAbstract</code>, with no UI.
+ */
+public class ZssEditorTest extends ActivityInstrumentationTestCase2<MockActivity> {
+    private static final String JS_CALLBACK_HANDLER = "nativeCallbackHandler";
+
+    private Instrumentation mInstrumentation;
+    private EditorWebViewAbstract mWebView;
+
+    private CountDownLatch mSetUpLatch;
+
+    private TestMethod mTestMethod;
+    private CountDownLatch mCallbackLatch;
+    private CountDownLatch mDomLoadedCallbackLatch;
+    private Set<String> mCallbackSet;
+
+    private enum TestMethod {
+        INIT
+    }
+
+    public ZssEditorTest() {
+        super(MockActivity.class);
+    }
+
+    @SuppressLint("AddJavascriptInterface")
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        mInstrumentation = getInstrumentation();
+        Activity activity = getActivity();
+        mSetUpLatch = new CountDownLatch(1);
+        mDomLoadedCallbackLatch = new CountDownLatch(1);
+
+        mSetUpLatch.countDown();
+
+        final String htmlEditor = Utils.getHtmlFromFile(activity, "android-editor.html");
+        activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                mWebView = new EditorWebView(mInstrumentation.getContext(), null);
+                mWebView.addJavascriptInterface(new MockJsCallbackReceiver(), JS_CALLBACK_HANDLER);
+                mWebView.loadDataWithBaseURL("file:///android_asset/", htmlEditor, "text/html", "utf-8", "");
+                mSetUpLatch.countDown();
+            }
+        });
+    }
+
+    public void testInitialization() throws InterruptedException {
+        // Wait for setUp() to finish initializing the WebView
+        mSetUpLatch.await();
+
+        // Identify this method to the MockJsCallbackReceiver
+        mTestMethod = TestMethod.INIT;
+
+        // Expecting three startup callbacks from the ZSS editor
+        mCallbackLatch = new CountDownLatch(3);
+        mCallbackSet = new HashSet<>();
+        boolean callbacksReceived = mCallbackLatch.await(5, TimeUnit.SECONDS);
+        assertTrue(callbacksReceived);
+
+        Set<String> expectedSet = new HashSet<>();
+        expectedSet.add("callback-new-field:id=zss_field_title");
+        expectedSet.add("callback-new-field:id=zss_field_content");
+        expectedSet.add("callback-dom-loaded:undefined");
+
+        assertEquals(expectedSet, mCallbackSet);
+    }
+
+    private class MockJsCallbackReceiver {
+        @JavascriptInterface
+        public void executeCallback(String callbackId, String params) {
+            if (callbackId.equals("callback-dom-loaded")) {
+                // Notify test methods that the dom has loaded
+                mDomLoadedCallbackLatch.countDown();
+            }
+
+            // Handle callbacks and count down latches according to the currently running test
+            switch(mTestMethod) {
+                case INIT:
+                    if (callbackId.equals("callback-new-field") || callbackId.equals("callback-dom-loaded")) {
+                        mCallbackSet.add(callbackId + ":" + params);
+                        mCallbackLatch.countDown();
+                    }
+                    break;
+                default:
+                    throw(new RuntimeException("Unknown calling method"));
+            }
+        }
+    }
+}

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -118,7 +118,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         super.onDetach();
     }
 
-    private void initJsEditor() {
+    protected void initJsEditor() {
         String htmlEditor = Utils.getHtmlFromFile(mActivity, "android-editor.html");
 
         mWebView.addJavascriptInterface(new JsCallbackReceiver(this), JS_CALLBACK_HANDLER);


### PR DESCRIPTION
Addresses #128, adding support for integration tests using the [Android testing framework](http://developer.android.com/tools/testing/testing_android.html).

I also added a few actual tests, which test some of the `EditorFragment`'s functionality with a real, live `ZSSEditor`. There's also a class for testing the `ZSSEditor` inside an `EditorWebView`, with no UI. The only test in this class for now makes sure that startup callbacks are being sent from JavaScript.

These tests aren't part of Travis' build script yet - they have to be run manually using `gradlew connectedAndroidTest`. In my opinion, we can consider adding these to Travis when the editor is further along and we have some idea of the extent and duration of the tests.
