### PR TITLE
Issue #166: don't hold a reference to containing activity

### DIFF
--- a/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/EditorFragmentForTests.java
+++ b/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/EditorFragmentForTests.java
@@ -5,10 +5,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import org.wordpress.android.editor.EditorFragment;
-import org.wordpress.android.editor.EditorWebViewAbstract;
-import org.wordpress.android.editor.R;
-
 import java.util.Map;
 
 public class EditorFragmentForTests extends EditorFragment {

--- a/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/EditorFragmentTest.java
+++ b/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/EditorFragmentTest.java
@@ -5,8 +5,6 @@ import android.test.ActivityInstrumentationTestCase2;
 import android.view.View;
 import android.widget.ToggleButton;
 
-import org.wordpress.android.editor.R;
-
 import java.util.HashMap;
 import java.util.Map;
 

--- a/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/MockEditorActivity.java
+++ b/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/MockEditorActivity.java
@@ -6,8 +6,6 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.LinearLayout;
 
-import org.wordpress.android.editor.EditorFragment;
-import org.wordpress.android.editor.EditorFragmentAbstract;
 import org.wordpress.android.util.helpers.MediaFile;
 
 public class MockEditorActivity extends AppCompatActivity implements EditorFragmentAbstract.EditorFragmentListener {

--- a/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/MockEditorActivity.java
+++ b/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/MockEditorActivity.java
@@ -3,14 +3,14 @@ package org.wordpress.android.editor;
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.widget.LinearLayout;
 
 import org.wordpress.android.editor.EditorFragment;
 import org.wordpress.android.editor.EditorFragmentAbstract;
 import org.wordpress.android.util.helpers.MediaFile;
 
-public class MockEditorActivity extends ActionBarActivity implements EditorFragmentAbstract.EditorFragmentListener {
+public class MockEditorActivity extends AppCompatActivity implements EditorFragmentAbstract.EditorFragmentListener {
     public static final int LAYOUT_ID = 999;
 
     @SuppressWarnings("ResourceType")

--- a/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/ZssEditorTest.java
+++ b/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/ZssEditorTest.java
@@ -6,10 +6,6 @@ import android.app.Instrumentation;
 import android.test.ActivityInstrumentationTestCase2;
 import android.webkit.JavascriptInterface;
 
-import org.wordpress.android.editor.EditorWebView;
-import org.wordpress.android.editor.EditorWebViewAbstract;
-import org.wordpress.android.editor.Utils;
-
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -6,7 +6,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Looper;
 import android.support.v7.app.ActionBar;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.text.Spanned;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -75,7 +75,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mActionBar = ((ActionBarActivity) getActivity()).getSupportActionBar();
+        mActionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
     }
 
     @Override

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -51,7 +51,6 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     private String mContentHtml = "";
 
     private EditorWebViewAbstract mWebView;
-    private ActionBar mActionBar;
 
     private boolean mHideActionBarOnSoftKeyboardUp;
 
@@ -75,7 +74,6 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mActionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
     }
 
     @Override
@@ -96,8 +94,9 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         mWebView.setOnImeBackListener(new EditorWebViewAbstract.OnImeBackListener() {
             @Override
             public void onImeBack() {
-                if (mHideActionBarOnSoftKeyboardUp && mActionBar != null && !mActionBar.isShowing()) {
-                    mActionBar.show();
+                ActionBar actionBar = getActionBar();
+                if (mHideActionBarOnSoftKeyboardUp && actionBar != null && !actionBar.isShowing()) {
+                    actionBar.show();
                 }
             }
         });
@@ -146,6 +145,18 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     @Override
     public void onDetach() {
         super.onDetach();
+    }
+
+    private ActionBar getActionBar() {
+        if (!isAdded()) {
+            return null;
+        }
+
+        if (getActivity() instanceof AppCompatActivity) {
+            return ((AppCompatActivity) getActivity()).getSupportActionBar();
+        } else {
+            return null;
+        }
     }
 
     @Override
@@ -202,8 +213,9 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     public boolean onTouch(View view, MotionEvent event) {
         if (mHideActionBarOnSoftKeyboardUp && event.getAction() == MotionEvent.ACTION_UP) {
             // If the WebView has received a touch event, the keyboard will be displayed and the action bar should hide
-            if (isAdded() && mActionBar != null && mActionBar.isShowing()) {
-                mActionBar.hide();
+            ActionBar actionBar = getActionBar();
+            if (actionBar != null && actionBar.isShowing()) {
+                actionBar.hide();
                 return false;
             }
         }
@@ -314,8 +326,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_content').setHTML('" +
                         Utils.escapeHtml(mContentHtml) + "');");
 
-                if (mHideActionBarOnSoftKeyboardUp) {
-                    mActionBar.hide();
+                if (mHideActionBarOnSoftKeyboardUp && getActionBar() != null) {
+                    getActionBar().hide();
                 }
             }
         });

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -50,7 +50,6 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     private String mTitle = "";
     private String mContentHtml = "";
 
-    private ActionBarActivity mActivity;
     private EditorWebViewAbstract mWebView;
     private ActionBar mActionBar;
 
@@ -76,8 +75,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mActivity = (ActionBarActivity) getActivity();
-        mActionBar = mActivity.getSupportActionBar();
+        mActionBar = ((ActionBarActivity) getActivity()).getSupportActionBar();
     }
 
     @Override
@@ -164,7 +162,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     }
 
     protected void initJsEditor() {
-        String htmlEditor = Utils.getHtmlFromFile(mActivity, "android-editor.html");
+        String htmlEditor = Utils.getHtmlFromFile(getActivity(), "android-editor.html");
 
         mWebView.addJavascriptInterface(new JsCallbackReceiver(this), JS_CALLBACK_HANDLER);
 
@@ -243,7 +241,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         mGetTitleCountDownLatch = new CountDownLatch(1);
 
         // All WebView methods must be called from the UI thread
-        mActivity.runOnUiThread(new Runnable() {
+        getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_title').getHTMLForCallback();");
@@ -273,7 +271,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         mGetContentCountDownLatch = new CountDownLatch(1);
 
         // All WebView methods must be called from the UI thread
-        mActivity.runOnUiThread(new Runnable() {
+        getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_content').getHTMLForCallback();");

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -173,6 +173,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     }
 
     protected void initJsEditor() {
+        if(!isAdded()) {
+            return;
+        }
+
         String htmlEditor = Utils.getHtmlFromFile(getActivity(), "android-editor.html");
 
         mWebView.addJavascriptInterface(new JsCallbackReceiver(this), JS_CALLBACK_HANDLER);
@@ -246,6 +250,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
      */
     @Override
     public CharSequence getTitle() {
+        if (!isAdded()) {
+            return "";
+        }
+
         if (Looper.myLooper() == Looper.getMainLooper()) {
             AppLog.d(T.EDITOR, "getTitle() called from UI thread");
         }
@@ -276,6 +284,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
      */
     @Override
     public CharSequence getContent() {
+        if (!isAdded()) {
+            return "";
+        }
+
         if (Looper.myLooper() == Looper.getMainLooper()) {
             AppLog.d(T.EDITOR, "getContent() called from UI thread");
         }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
@@ -14,7 +14,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Parcelable;
 import android.support.v7.app.ActionBar;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.text.Editable;
 import android.text.Layout;
 import android.text.Selection;
@@ -88,7 +88,6 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
     private static final String TAG_FORMAT_BAR_BUTTON_STRIKE = "strike";
     private static final String TAG_FORMAT_BAR_BUTTON_QUOTE = "blockquote";
 
-    private ActionBarActivity mActivity;
     private View mRootView;
     private WPEditText mContentEditText;
     private EditText mTitleEditText;
@@ -110,7 +109,7 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
     @Override
     public boolean onBackPressed() {
         // leave full screen mode back button is pressed
-        if (getActivity().getActionBar() != null && !getActivity().getActionBar().isShowing()) {
+        if (getActionBar() != null && !getActionBar().isShowing()) {
             setContentEditingModeVisible(false);
             return true;
         }
@@ -165,8 +164,6 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        mActivity = (ActionBarActivity) getActivity();
-
         final ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.fragment_edit_post_content, container, false);
 
         mFormatBar = (LinearLayout) rootView.findViewById(R.id.format_bar);
@@ -176,8 +173,8 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
             @Override
             public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
                 // Go to full screen editor when 'next' button is tapped on soft keyboard
-                if (actionId == EditorInfo.IME_ACTION_NEXT && isAdded() && mActivity.getSupportActionBar() != null &&
-                        mActivity.getSupportActionBar().isShowing()) {
+                ActionBar actionBar = getActionBar();
+                if (actionId == EditorInfo.IME_ACTION_NEXT && actionBar != null && actionBar.isShowing()) {
                     setContentEditingModeVisible(true);
                 }
                 return false;
@@ -215,8 +212,8 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
             public void onImeBack(WPEditText ctrl, String text) {
                 // Go back to regular editor if IME keyboard is dismissed
                 // Bottom comparison is there to ensure that the keyboard is actually showing
-                if (mRootView.getBottom() < mFullViewBottom && isAdded() && mActivity.getSupportActionBar() != null
-                        && !mActivity.getSupportActionBar().isShowing()) {
+                ActionBar actionBar = getActionBar();
+                if (mRootView.getBottom() < mFullViewBottom && actionBar != null && !actionBar.isShowing()) {
                     setContentEditingModeVisible(false);
                 }
             }
@@ -265,11 +262,22 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
         }
     };
 
+    private ActionBar getActionBar() {
+        if (!isAdded()) {
+            return null;
+        }
+        if (getActivity() instanceof AppCompatActivity) {
+            return ((AppCompatActivity) getActivity()).getSupportActionBar();
+        } else {
+            return null;
+        }
+    }
+
     public void setContentEditingModeVisible(boolean isVisible) {
         if (!isAdded()) {
             return;
         }
-        ActionBar actionBar = mActivity.getSupportActionBar();
+        ActionBar actionBar = getActionBar();
         if (isVisible) {
             Animation fadeAnimation = new AlphaAnimation(1, 0);
             fadeAnimation.setDuration(CONTENT_ANIMATION_DURATION);
@@ -314,7 +322,7 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
                 }
             });
             mPostContentLinearLayout.startAnimation(fadeAnimation);
-            mActivity.invalidateOptionsMenu();
+            getActivity().invalidateOptionsMenu();
             if (actionBar != null) {
                 actionBar.show();
             }
@@ -661,7 +669,8 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
         mLastYPos = pos;
 
         if (event.getAction() == MotionEvent.ACTION_UP) {
-            if (isAdded() && mActivity.getSupportActionBar() != null && mActivity.getSupportActionBar().isShowing()) {
+            ActionBar actionBar = getActionBar();
+            if (actionBar != null && actionBar.isShowing()) {
                 setContentEditingModeVisible(true);
                 return false;
             }
@@ -811,7 +820,7 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
                     final MediaGalleryImageSpan gallerySpan = gallerySpans[0];
                     Intent intent = new Intent(ACTION_MEDIA_GALLERY_TOUCHED);
                     intent.putExtra(EXTRA_MEDIA_GALLERY, gallerySpan.getMediaGallery());
-                    mActivity.sendBroadcast(intent);
+                    getActivity().sendBroadcast(intent);
                 }
             }
         } else if (event.getAction() == 1) {
@@ -1019,7 +1028,7 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
     public void addMediaFile(final MediaFile mediaFile, final String imageUrl, final ImageLoader imageLoader, final int start, final int end) {
         mediaFile.setFileURL(imageUrl);
         mediaFile.setFilePath(imageUrl);
-        final WPEditImageSpan imageSpan = createWPEditImageSpan(mActivity, mediaFile);
+        final WPEditImageSpan imageSpan = createWPEditImageSpan(getActivity(), mediaFile);
         mEditorFragmentListener.saveMediaFile(mediaFile);
         imageSpan.setMediaFile(mediaFile);
 

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/legacy/EditLinkActivity.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/legacy/EditLinkActivity.java
@@ -1,15 +1,15 @@
 package org.wordpress.android.editor.legacy;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 
 import org.wordpress.android.editor.R;
 
-public class EditLinkActivity extends ActionBarActivity {
+public class EditLinkActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
+++ b/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
@@ -3,14 +3,14 @@ package org.wordpress.android.editor.example;
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 
 import org.wordpress.android.editor.EditorFragmentAbstract;
 import org.wordpress.android.editor.EditorFragmentAbstract.EditorFragmentListener;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 
-public class EditorExampleActivity extends ActionBarActivity implements EditorFragmentListener {
+public class EditorExampleActivity extends AppCompatActivity implements EditorFragmentListener {
     public static final String EDITOR_PARAM = "EDITOR_PARAM";
     public static final String TITLE_PARAM = "TITLE_PARAM";
     public static final String CONTENT_PARAM = "CONTENT_PARAM";

--- a/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
+++ b/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.editor.example;
 
 import android.app.Fragment;
-import android.app.FragmentManager;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 

--- a/example/src/main/java/org/wordpress/example/MainExampleActivity.java
+++ b/example/src/main/java/org/wordpress/example/MainExampleActivity.java
@@ -3,7 +3,7 @@ package org.wordpress.android.editor.example;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
@@ -11,7 +11,7 @@ import android.widget.Button;
 import org.wordpress.android.editor.Utils;
 import org.wordpress.android.editor.example.EditorExampleActivity;
 
-public class MainExampleActivity extends ActionBarActivity {
+public class MainExampleActivity extends AppCompatActivity {
     private Activity mActivity;
 
     @Override


### PR DESCRIPTION
Addresses #166. Removes reliance on `ActionBarActivity` in the `EditorFragment` and also makes some preventative fixes to avoid possible memory leaks/NPE crashes.
- Updated all usages of `ActionBarActivity` to `AppCompatActivity` (`ActionBarActivity` deprecated as of support library `v22`)
- Stopped holding references to the containing activity and action bar in `EditorFragment`
- Added `isAdded()` checks before all calls to `getActivity()`
