### PR TITLE
Feature #181: Empty content button in example app

### DIFF
--- a/example/src/main/java/org/wordpress/example/MainExampleActivity.java
+++ b/example/src/main/java/org/wordpress/example/MainExampleActivity.java
@@ -34,6 +34,19 @@ public class MainExampleActivity extends AppCompatActivity {
             }
         });
 
+        Button newEditorPostEmpty = (Button) findViewById(R.id.new_editor_post_empty);
+        newEditorPostEmpty.setOnClickListener(new OnClickListener() {
+            @Override public void onClick(View v) {
+                Intent intent = new Intent(MainExampleActivity.this, EditorExampleActivity.class);
+                Bundle bundle = new Bundle();
+                bundle.putString(EditorExampleActivity.TITLE_PARAM, "");
+                bundle.putString(EditorExampleActivity.CONTENT_PARAM, "");
+                bundle.putInt(EditorExampleActivity.EDITOR_PARAM, EditorExampleActivity.USE_NEW_EDITOR);
+                intent.putExtras(bundle);
+                startActivity(intent);
+            }
+        });
+
         Button legacyEditorPost1Local = (Button) findViewById(R.id.legacy_editor_post_1_local);
         legacyEditorPost1Local.setOnClickListener(new OnClickListener() {
             @Override public void onClick(View v) {

--- a/example/src/main/res/layout/activity_example.xml
+++ b/example/src/main/res/layout/activity_example.xml
@@ -16,11 +16,20 @@
     <Button
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:text="New Editor - Empty Post"
+        android:id="@+id/new_editor_post_empty"
+        android:layout_marginTop="32dp"
+        android:layout_centerHorizontal="true"
+        android:layout_below="@id/new_editor_post_1"/>
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:text="Legacy Editor - Post 1 - Local Draft"
         android:id="@+id/legacy_editor_post_1_local"
         android:layout_marginTop="32dp"
         android:layout_centerHorizontal="true"
-        android:layout_below="@id/new_editor_post_1"/>
+        android:layout_below="@id/new_editor_post_empty"/>
 
     <Button
         android:layout_width="wrap_content"


### PR DESCRIPTION
Addresses #181. Adds a new button to the example app's launch screen which launches the new editor with no content. This should help with testing new post flow.

![example-app-empty-button](https://cloud.githubusercontent.com/assets/9613966/8621828/bcc70fa0-26f5-11e5-914d-ea92afbb7f8d.png)
