### PR TITLE
Issue #171: Show placeholder text

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -469,7 +469,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     }
 
     private void updateVisualEditorFields() {
-        mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_title').setHTML('" +
+        mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_title').setPlainText('" +
                 Utils.escapeHtml(mTitle) + "');");
         mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_content').setHTML('" +
                 Utils.escapeHtml(mContentHtml) + "');");

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -52,6 +52,9 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     private SourceViewEditText mSourceViewTitle;
     private SourceViewEditText mSourceViewContent;
 
+    private String mTitlePlaceholder = "";
+    private String mContentPlaceholder = "";
+
     private boolean mHideActionBarOnSoftKeyboardUp;
 
     private CountDownLatch mGetTitleCountDownLatch;
@@ -116,6 +119,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
         mSourceViewTitle.setOnImeBackListener(this);
         mSourceViewContent.setOnImeBackListener(this);
+
+        mSourceViewTitle.setHint(mTitlePlaceholder);
 
         // -- Format bar configuration
 
@@ -369,10 +374,26 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         return null;
     }
 
+    @Override
+    public void setTitlePlaceholder(CharSequence placeholderText) {
+        mTitlePlaceholder = placeholderText.toString();
+    }
+
+    @Override
+    public void setContentPlaceholder(CharSequence placeholderText) {
+        mContentPlaceholder = placeholderText.toString();
+    }
+
     public void onDomLoaded() {
         mWebView.post(new Runnable() {
             public void run() {
                 mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_content').setMultiline('true');");
+
+                // Set title and content placeholder text
+                mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_title').setPlaceholderText('" +
+                        mTitlePlaceholder + "');");
+                mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_content').setPlaceholderText('" +
+                        mContentPlaceholder + "');");
 
                 // Load title and content into ZSSEditor
                 updateVisualEditorFields();

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -18,6 +18,8 @@ public abstract class EditorFragmentAbstract extends Fragment {
     public abstract CharSequence getContent();
     public abstract void appendMediaFile(MediaFile mediaFile, String imageUrl, ImageLoader imageLoader);
     public abstract void appendGallery(MediaGallery mediaGallery);
+    public abstract void setTitlePlaceholder(CharSequence text);
+    public abstract void setContentPlaceholder(CharSequence text);
 
     // TODO: remove this as soon as we can (we'll need to drop the legacy editor or fix html2spanned translation)
     public abstract Spanned getSpannedContent();

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
@@ -1129,4 +1129,14 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
         editableText.setSpan(as, selectionStart, selectionEnd + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
         editableText.insert(selectionEnd + 1, "\n\n");
     }
+
+    @Override
+    public void setTitlePlaceholder(CharSequence text) {
+
+    }
+
+    @Override
+    public void setContentPlaceholder(CharSequence text) {
+
+    }
 }

--- a/WordPressEditor/src/main/res/layout-sw600dp/fragment_editor.xml
+++ b/WordPressEditor/src/main/res/layout-sw600dp/fragment_editor.xml
@@ -39,7 +39,7 @@
                 android:layout_marginBottom="@dimen/sourceview_title_bottom_margin"
                 android:background="@null"
                 android:textSize="24sp"
-                android:hint="@string/post_title"
+                android:textColorHint="@color/placeholder_text"
                 android:inputType="textCapSentences|textAutoCorrect"
                 android:imeOptions="flagNoExtractUi"
                 editor:fontFile="Merriweather-Bold.ttf"/>
@@ -64,7 +64,7 @@
                 android:background="@null"
                 android:textSize="16sp"
                 android:maxLength="10000000"
-                android:hint="@string/post_content"
+                android:textColorHint="@color/placeholder_text"
                 android:inputType="textMultiLine|textCapSentences|textNoSuggestions"
                 android:lineSpacingExtra="4dp"
                 android:imeOptions="flagNoExtractUi"

--- a/WordPressEditor/src/main/res/layout-sw600dp/fragment_editor.xml
+++ b/WordPressEditor/src/main/res/layout-sw600dp/fragment_editor.xml
@@ -39,7 +39,7 @@
                 android:layout_marginBottom="@dimen/sourceview_title_bottom_margin"
                 android:background="@null"
                 android:textSize="24sp"
-                android:textColorHint="@color/placeholder_text"
+                android:textColorHint="@color/sourceview_placeholder_text"
                 android:inputType="textCapSentences|textAutoCorrect"
                 android:imeOptions="flagNoExtractUi"
                 editor:fontFile="Merriweather-Bold.ttf"/>
@@ -64,7 +64,7 @@
                 android:background="@null"
                 android:textSize="16sp"
                 android:maxLength="10000000"
-                android:textColorHint="@color/placeholder_text"
+                android:textColorHint="@color/sourceview_placeholder_text"
                 android:inputType="textMultiLine|textCapSentences|textNoSuggestions"
                 android:lineSpacingExtra="4dp"
                 android:imeOptions="flagNoExtractUi"

--- a/WordPressEditor/src/main/res/layout/fragment_editor.xml
+++ b/WordPressEditor/src/main/res/layout/fragment_editor.xml
@@ -39,6 +39,7 @@
                 android:layout_marginBottom="@dimen/sourceview_title_bottom_margin"
                 android:background="@null"
                 android:textSize="24sp"
+                android:textColorHint="@color/placeholder_text"
                 android:inputType="textCapSentences|textAutoCorrect"
                 android:imeOptions="flagNoExtractUi"
                 editor:fontFile="Merriweather-Bold.ttf"/>
@@ -63,6 +64,7 @@
                 android:background="@null"
                 android:textSize="16sp"
                 android:maxLength="10000000"
+                android:textColorHint="@color/placeholder_text"
                 android:inputType="textMultiLine|textCapSentences|textAutoCorrect"
                 android:lineSpacingExtra="4dp"
                 android:imeOptions="flagNoExtractUi"

--- a/WordPressEditor/src/main/res/layout/fragment_editor.xml
+++ b/WordPressEditor/src/main/res/layout/fragment_editor.xml
@@ -39,7 +39,6 @@
                 android:layout_marginBottom="@dimen/sourceview_title_bottom_margin"
                 android:background="@null"
                 android:textSize="24sp"
-                android:hint="@string/post_title"
                 android:inputType="textCapSentences|textAutoCorrect"
                 android:imeOptions="flagNoExtractUi"
                 editor:fontFile="Merriweather-Bold.ttf"/>
@@ -64,7 +63,6 @@
                 android:background="@null"
                 android:textSize="16sp"
                 android:maxLength="10000000"
-                android:hint="@string/post_content"
                 android:inputType="textMultiLine|textCapSentences|textAutoCorrect"
                 android:lineSpacingExtra="4dp"
                 android:imeOptions="flagNoExtractUi"

--- a/WordPressEditor/src/main/res/layout/fragment_editor.xml
+++ b/WordPressEditor/src/main/res/layout/fragment_editor.xml
@@ -39,7 +39,7 @@
                 android:layout_marginBottom="@dimen/sourceview_title_bottom_margin"
                 android:background="@null"
                 android:textSize="24sp"
-                android:textColorHint="@color/placeholder_text"
+                android:textColorHint="@color/sourceview_placeholder_text"
                 android:inputType="textCapSentences|textAutoCorrect"
                 android:imeOptions="flagNoExtractUi"
                 editor:fontFile="Merriweather-Bold.ttf"/>
@@ -64,7 +64,7 @@
                 android:background="@null"
                 android:textSize="16sp"
                 android:maxLength="10000000"
-                android:textColorHint="@color/placeholder_text"
+                android:textColorHint="@color/sourceview_placeholder_text"
                 android:inputType="textMultiLine|textCapSentences|textNoSuggestions"
                 android:lineSpacingExtra="4dp"
                 android:imeOptions="flagNoExtractUi"

--- a/WordPressEditor/src/main/res/values/colors.xml
+++ b/WordPressEditor/src/main/res/values/colors.xml
@@ -10,7 +10,6 @@
     <color name="format_bar_button_normal_color">@color/wp_gray</color>
     <color name="format_bar_button_highlighted_color">@color/wp_blue</color>
 
-    <color name="placeholder_text">@color/wp_gray</color>
-
     <color name="sourceview_separator">@color/wp_gray_lighten_30</color>
+    <color name="sourceview_placeholder_text">@color/wp_gray</color>
 </resources>

--- a/WordPressEditor/src/main/res/values/colors.xml
+++ b/WordPressEditor/src/main/res/values/colors.xml
@@ -10,5 +10,7 @@
     <color name="format_bar_button_normal_color">@color/wp_gray</color>
     <color name="format_bar_button_highlighted_color">@color/wp_blue</color>
 
+    <color name="placeholder_text">@color/wp_gray</color>
+
     <color name="sourceview_separator">@color/wp_gray_lighten_30</color>
 </resources>

--- a/WordPressEditor/src/test/java/org/wordpress/android/editor/EditorFragmentAbstractTest.java
+++ b/WordPressEditor/src/test/java/org/wordpress/android/editor/EditorFragmentAbstractTest.java
@@ -70,6 +70,16 @@ public class EditorFragmentAbstractTest {
         }
 
         @Override
+        public void setTitlePlaceholder(CharSequence text) {
+
+        }
+
+        @Override
+        public void setContentPlaceholder(CharSequence text) {
+
+        }
+
+        @Override
         public Spanned getSpannedContent() {
             return null;
         }

--- a/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
+++ b/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
@@ -14,6 +14,8 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
     public static final String TITLE_PARAM = "TITLE_PARAM";
     public static final String CONTENT_PARAM = "CONTENT_PARAM";
     public static final String DRAFT_PARAM = "DRAFT_PARAM";
+    public static final String TITLE_PLACEHOLDER_PARAM = "TITLE_PLACEHOLDER_PARAM";
+    public static final String CONTENT_PLACEHOLDER_PARAM = "CONTENT_PLACEHOLDER_PARAM";
     public static final int USE_NEW_EDITOR = 1;
     public static final int USE_LEGACY_EDITOR = 2;
 
@@ -61,6 +63,8 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
         boolean isLocalDraft = getIntent().getBooleanExtra(DRAFT_PARAM, true);
         mEditorFragment.setTitle(title);
         mEditorFragment.setContent(content);
+        mEditorFragment.setTitlePlaceholder(getIntent().getStringExtra(TITLE_PLACEHOLDER_PARAM));
+        mEditorFragment.setContentPlaceholder(getIntent().getStringExtra(CONTENT_PLACEHOLDER_PARAM));
         mEditorFragment.setLocalDraft(isLocalDraft);
     }
 

--- a/example/src/main/java/org/wordpress/example/MainExampleActivity.java
+++ b/example/src/main/java/org/wordpress/example/MainExampleActivity.java
@@ -28,6 +28,10 @@ public class MainExampleActivity extends AppCompatActivity {
                 bundle.putString(EditorExampleActivity.TITLE_PARAM, getString(R.string.example_post_visual_title));
                 bundle.putString(EditorExampleActivity.CONTENT_PARAM, Utils.getHtmlFromFile(mActivity,
                         "example-content.html"));
+                bundle.putString(EditorExampleActivity.TITLE_PLACEHOLDER_PARAM,
+                        getString(R.string.example_post_title_placeholder));
+                bundle.putString(EditorExampleActivity.CONTENT_PLACEHOLDER_PARAM,
+                        getString(R.string.example_post_content_placeholder));
                 bundle.putInt(EditorExampleActivity.EDITOR_PARAM, EditorExampleActivity.USE_NEW_EDITOR);
                 intent.putExtras(bundle);
                 startActivity(intent);
@@ -41,6 +45,10 @@ public class MainExampleActivity extends AppCompatActivity {
                 Bundle bundle = new Bundle();
                 bundle.putString(EditorExampleActivity.TITLE_PARAM, "");
                 bundle.putString(EditorExampleActivity.CONTENT_PARAM, "");
+                bundle.putString(EditorExampleActivity.TITLE_PLACEHOLDER_PARAM,
+                        getString(R.string.example_post_title_placeholder));
+                bundle.putString(EditorExampleActivity.CONTENT_PLACEHOLDER_PARAM,
+                        getString(R.string.example_post_content_placeholder));
                 bundle.putInt(EditorExampleActivity.EDITOR_PARAM, EditorExampleActivity.USE_NEW_EDITOR);
                 intent.putExtras(bundle);
                 startActivity(intent);

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <string name="starting_legacy_editor">Starting legacy editor</string>
     <string name="starting_new_editor">Starting new editor</string>
     <string name="example_post_visual_title">I\'m editing a post!</string>
+    <string name="example_post_title_placeholder">Post title</string>
+    <string name="example_post_content_placeholder">Share your story here…</string>
     <string name="example_post_1_title">Post 1</string>
     <string name="example_post_1_content">Post 1 Content:\nBest post ever!</string>
     <string name="example_post_2_title">Post 2</string>

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -2054,7 +2054,7 @@ ZSSField.prototype.emptyFieldIfNoContents = function() {
     var nbsp = '\xa0';
     var text = this.wrappedObject.text().replace(nbsp, '');
 
-    if (text.length == 0) {
+    if (text.length == 0 || text == '\u000A') {
 
         var hasChildImages = (this.wrappedObject.find('img').length > 0);
         var hasUnorderedList = (this.wrappedObject.find('ul').length > 0);

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -2019,7 +2019,6 @@ function ZSSField(wrappedObject) {
 
     this.multiline = false;
     this.wrappedObject = wrappedObject;
-    this.bodyPlaceholderColor = '#000000';
 
     if (this.wrappedDomNode().hasAttribute('nostyle')) {
         this.hasNoStyle = true;
@@ -2067,17 +2066,12 @@ ZSSField.prototype.emptyFieldIfNoContents = function() {
     }
 };
 
-ZSSField.prototype.emptyFieldIfNoContentsAndRefreshPlaceholderColor = function() {
-    this.emptyFieldIfNoContents();
-    this.refreshPlaceholderColor();
-};
-
 // MARK: - Handle event listeners
 
 ZSSField.prototype.handleBlurEvent = function(e) {
     ZSSEditor.focusedField = null;
 
-    this.emptyFieldIfNoContentsAndRefreshPlaceholderColor();
+    this.emptyFieldIfNoContents();
 
     this.callback("callback-focus-out");
 };
@@ -2085,10 +2079,6 @@ ZSSField.prototype.handleBlurEvent = function(e) {
 ZSSField.prototype.handleFocusEvent = function(e) {
     ZSSEditor.focusedField = this;
 
-    // IMPORTANT: this is the only case where checking the current focus will not work.
-    // We sidestep this issue by indicating that the field is about to gain focus.
-    //
-    this.refreshPlaceholderColorAboutToGainFocus(true);
     this.callback("callback-focus-in");
 };
 
@@ -2115,7 +2105,7 @@ ZSSField.prototype.handleInputEvent = function(e) {
     // as the field could become empty because of a cut or paste operation as well as a key press.
     // This event takes care of all cases.
     //
-    this.emptyFieldIfNoContentsAndRefreshPlaceholderColor();
+    this.emptyFieldIfNoContents();
 
     var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
     ZSSEditor.callback('callback-selection-changed', joinedArguments);
@@ -2371,7 +2361,6 @@ ZSSField.prototype.strippedHTML = function() {
 ZSSField.prototype.setPlainText = function(text) {
     ZSSEditor.currentEditingImage = null;
     this.wrappedObject.text(text);
-    this.refreshPlaceholderColor();
 };
 
 ZSSField.prototype.setHTML = function(html) {
@@ -2379,7 +2368,6 @@ ZSSField.prototype.setHTML = function(html) {
     var mutatedHTML = wp.loadText(html);
     mutatedHTML = ZSSEditor.applyVisualFormatting(mutatedHTML);
     this.wrappedObject.html(mutatedHTML);
-    this.refreshPlaceholderColor();
 };
 
 // MARK: - Placeholder
@@ -2389,41 +2377,7 @@ ZSSField.prototype.hasPlaceholderText = function() {
 };
 
 ZSSField.prototype.setPlaceholderText = function(placeholder) {
-
     this.wrappedObject.attr('placeholderText', placeholder);
-};
-
-ZSSField.prototype.setPlaceholderColor = function(color) {
-    this.bodyPlaceholderColor = color;
-    this.refreshPlaceholderColor();
-};
-
-ZSSField.prototype.refreshPlaceholderColor = function() {
-     this.refreshPlaceholderColorForAttributes(this.hasPlaceholderText(),
-                                               this.isFocused(),
-                                               this.isEmpty());
-};
-
-ZSSField.prototype.refreshPlaceholderColorAboutToGainFocus = function(willGainFocus) {
-    this.refreshPlaceholderColorForAttributes(this.hasPlaceholderText(),
-                                              willGainFocus,
-                                              this.isEmpty());
-};
-
-ZSSField.prototype.refreshPlaceholderColorForAttributes = function(hasPlaceholderText, isFocused, isEmpty) {
-
-    var shouldColorText = hasPlaceholderText && isEmpty;
-
-    if (shouldColorText) {
-        if (isFocused) {
-            this.wrappedObject.css('color', this.bodyPlaceholderColor);
-        } else {
-            this.wrappedObject.css('color', this.bodyPlaceholderColor);
-        }
-    } else {
-        this.wrappedObject.css('color', '');
-    }
-
 };
 
 // MARK: - Wrapped Object

--- a/libs/editor-common/assets/editor-android.css
+++ b/libs/editor-common/assets/editor-android.css
@@ -1,13 +1,13 @@
 @media screen and (min-width: 720px) and (max-width: 1279px) {
     body {
-        padding-left:80px;
-        padding-right:80px;
+        padding-left:90px;
+        padding-right:90px;
     }
 }
 
 @media screen and (min-width: 1280px){
     body {
-        padding-left:160px;
-        padding-right:160px;
+        padding-left:170px;
+        padding-right:170px;
     }
 }

--- a/libs/editor-common/assets/editor.css
+++ b/libs/editor-common/assets/editor.css
@@ -287,6 +287,7 @@ div.field[contenteditable] {
 
 div.field[placeholderText][contenteditable=true]:empty:before {
     content: attr(placeholderText);
+    color: #87a6bc;
     transition: 0.2s ease opacity;
 }
 

--- a/libs/editor-common/assets/editor.css
+++ b/libs/editor-common/assets/editor.css
@@ -73,10 +73,10 @@ html, body {
 }
 
 body {
-    padding-left:5px;
-    padding-right:5px;
-    padding-top: 0px;
-    padding-bottom: 0px;
+    padding-left:15px;
+    padding-right:15px;
+    padding-top: 15px;
+    padding-bottom: 5px;
     overflow-y: auto;
     min-height: 100vh;
     word-wrap: break-word;
@@ -280,7 +280,6 @@ progress.wp_media_indicator.failed::-webkit-progress-value {
 
 
 div.field[contenteditable] {
-    padding: 15px 10px 5px 10px;
     box-sizing: border-box;
     font-size: 16px;
 }
@@ -297,8 +296,8 @@ div.field[placeholderText][contenteditable=true]:empty:focus:before {
 
 #separatorDiv {
     -webkit-user-select: none;
-    padding-left: 10px;
-    padding-right: 10px;
+    padding-top: 5px;
+    padding-bottom: 15px;
 }
 
 #zss_field_title, #zss_field_title p {


### PR DESCRIPTION
Fixes #171. Displays placeholder text for empty fields.

![171-placeholder-visual](https://cloud.githubusercontent.com/assets/9613966/8756418/1f93955e-2ca0-11e5-9271-945f584b00b8.png)

![171-placeholder-html](https://cloud.githubusercontent.com/assets/9613966/8756417/1bf5c2a0-2ca0-11e5-92cd-42d7f0d14924.png)

(no placeholder text for content in HTML mode, reflecting iOS)

Had some trouble with autocorrect (API 19+), the placeholder color would remain and color the actual text entered until space or entered was pressed. Fixed by setting a fixed color in the CSS and dropping the `ZSSEditor` methods that were handling setting it dynamically.

Note that the text in the editor is coming from the example app - the actual placeholders will be set from WPAndroid, so we can have 'Post Title' or 'Page Title' accordingly, as with iOS.
