### PR TITLE
Issue #188: Save changes in HTML mode

### DIFF
--- a/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/EditorFragmentTest.java
+++ b/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/EditorFragmentTest.java
@@ -145,6 +145,10 @@ public class EditorFragmentTest extends ActivityInstrumentationTestCase2<MockEdi
                 titleText.setText("new title");
                 contentText.setText("new <b>content</b>");
 
+                // Check that getTitle() and getContent() return latest version even in HTML mode
+                assertEquals("new title", mFragment.getTitle());
+                assertEquals("new <b>content</b>", mFragment.getContent());
+
                 htmlButton.performClick(); // Turn off HTML mode
 
                 uiThreadLatch2.countDown();

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -211,14 +211,14 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             updateFormatBarEnabledState(true);
 
             if (((ToggleButton) v).isChecked()) {
-                mWebView.setVisibility(View.GONE);
-                mSourceView.setVisibility(View.VISIBLE);
-
                 mSourceViewTitle.setText(getTitle());
 
                 SpannableString spannableContent = new SpannableString(getContent());
                 HtmlStyleUtils.styleHtmlForDisplay(spannableContent);
                 mSourceViewContent.setText(spannableContent);
+
+                mWebView.setVisibility(View.GONE);
+                mSourceView.setVisibility(View.VISIBLE);
 
                 mSourceViewContent.requestFocus();
                 mSourceViewContent.setSelection(0);
@@ -302,6 +302,11 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             return "";
         }
 
+        if (mSourceView.getVisibility() == View.VISIBLE) {
+            mTitle = mSourceViewTitle.getText().toString();
+            return StringUtils.notNullStr(mTitle);
+        }
+
         if (Looper.myLooper() == Looper.getMainLooper()) {
             AppLog.d(T.EDITOR, "getTitle() called from UI thread");
         }
@@ -334,6 +339,11 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     public CharSequence getContent() {
         if (!isAdded()) {
             return "";
+        }
+
+        if (mSourceView.getVisibility() == View.VISIBLE) {
+            mContentHtml = mSourceViewContent.getText().toString();
+            return StringUtils.notNullStr(mContentHtml);
         }
 
         if (Looper.myLooper() == Looper.getMainLooper()) {


### PR DESCRIPTION
Fixes #188 by modifying `getTitle()` and `getContent()` to check which mode is active (visual/HTML) and return text from that mode.

This can be tested by checking out a fresh branch in WPAndroid and running:

`git subtree pull --prefix=libs/editor git@github.com:wordpress-mobile/WordPress-Editor-Android.git issue/188-save-html-mode`

(previously, making changes in HTML mode and exiting the editor would cause those changes to be lost)
