### PR TITLE
Issue #165: Content field not filling remaining screen space

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -94,6 +94,20 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         mWebView.setOnTouchListener(this);
         mWebView.setOnImeBackListener(this);
 
+        // Ensure that the content field is always filling the remaining screen space
+        mWebView.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
+            @Override
+            public void onLayoutChange(View v, int left, int top, int right, int bottom,
+                                       int oldLeft, int oldTop, int oldRight, int oldBottom) {
+                mWebView.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        mWebView.execJavaScriptFromString("ZSSEditor.refreshVisibleViewportSize();");
+                    }
+                });
+            }
+        });
+
         mEditorFragmentListener.onEditorFragmentInitialized();
 
         initJsEditor();


### PR DESCRIPTION
Fixes #165. When the content field did not have enough text to fill the screen, tapping below the last line of text would not give focus to the field. This was especially irritating for empty documents.

(video of the issue: https://cloudup.com/cw8OQOfyTVd)

Fixed by calling the existing `ZSSEditor.refreshVisibleViewportSize()` whenever the `WebView`'s layout changed (initial setup, keyboard appearing and hiding).

cc @bummytime
