### PR TITLE
Fixes hiding/showing of action bar when changing orientations

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -203,10 +203,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE
                 && !getResources().getBoolean(R.bool.is_large_tablet_landscape)) {
             mHideActionBarOnSoftKeyboardUp = true;
-            this.hideActionBarIfNeeded();
+            hideActionBarIfNeeded();
         } else {
             mHideActionBarOnSoftKeyboardUp = false;
-            this.showActionBarIfNeeded();
+            showActionBarIfNeeded();
         }
     }
 
@@ -275,7 +275,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         if (event.getAction() == MotionEvent.ACTION_UP) {
             // If the WebView or EditText has received a touch event, the keyboard will be displayed and the action bar
             // should hide
-            this.hideActionBarIfNeeded();
+            hideActionBarIfNeeded();
         }
         return false;
     }
@@ -285,7 +285,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
      */
     @Override
     public void onImeBack() {
-        this.showActionBarIfNeeded();
+        showActionBarIfNeeded();
     }
 
     @SuppressLint("NewApi")
@@ -498,7 +498,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
         ActionBar actionBar = getActionBar();
         if (getActionBar() != null
-                && !this.isHardwareKeyboardPresent()
+                && !isHardwareKeyboardPresent()
                 && mHideActionBarOnSoftKeyboardUp
                 && actionBar.isShowing()) {
             getActionBar().hide();

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -200,11 +200,18 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         super.onConfigurationChanged(newConfig);
 
         // Toggle action bar auto-hiding for the new orientation
+        ActionBar actionBar = getActionBar();
         if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE
                 && !getResources().getBoolean(R.bool.is_large_tablet_landscape)) {
             mHideActionBarOnSoftKeyboardUp = true;
+            if (actionBar != null) {
+                actionBar.hide();
+            }
         } else {
             mHideActionBarOnSoftKeyboardUp = false;
+            if (actionBar != null) {
+                actionBar.show();
+            }
         }
     }
 

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -200,18 +200,13 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         super.onConfigurationChanged(newConfig);
 
         // Toggle action bar auto-hiding for the new orientation
-        ActionBar actionBar = getActionBar();
         if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE
                 && !getResources().getBoolean(R.bool.is_large_tablet_landscape)) {
             mHideActionBarOnSoftKeyboardUp = true;
-            if (actionBar != null) {
-                actionBar.hide();
-            }
+            this.hideActionBarIfNeeded();
         } else {
             mHideActionBarOnSoftKeyboardUp = false;
-            if (actionBar != null) {
-                actionBar.show();
-            }
+            this.showActionBarIfNeeded();
         }
     }
 
@@ -277,14 +272,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
     @Override
     public boolean onTouch(View view, MotionEvent event) {
-        if (mHideActionBarOnSoftKeyboardUp && event.getAction() == MotionEvent.ACTION_UP) {
+        if (event.getAction() == MotionEvent.ACTION_UP) {
             // If the WebView or EditText has received a touch event, the keyboard will be displayed and the action bar
             // should hide
-            ActionBar actionBar = getActionBar();
-            if (actionBar != null && actionBar.isShowing()) {
-                actionBar.hide();
-                return false;
-            }
+            this.hideActionBarIfNeeded();
         }
         return false;
     }
@@ -294,10 +285,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
      */
     @Override
     public void onImeBack() {
-        ActionBar actionBar = getActionBar();
-        if (mHideActionBarOnSoftKeyboardUp && actionBar != null && !actionBar.isShowing()) {
-            actionBar.show();
-        }
+        this.showActionBarIfNeeded();
     }
 
     @SuppressLint("NewApi")
@@ -434,10 +422,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
                 // Load title and content into ZSSEditor
                 updateVisualEditorFields();
-
-                if (mHideActionBarOnSoftKeyboardUp && getActionBar() != null) {
-                    getActionBar().hide();
-                }
+                hideActionBarIfNeeded();
 
                 // Reset all format bar buttons (in case they remained active through activity re-creation)
                 ToggleButton htmlButton = (ToggleButton) getActivity().findViewById(R.id.format_bar_button_html);
@@ -504,6 +489,43 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 Utils.escapeHtml(mTitle) + "');");
         mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_content').setHTML('" +
                 Utils.escapeHtml(mContentHtml) + "');");
+    }
+
+    /**
+     * Hide the action bar if needed.
+     */
+    private void hideActionBarIfNeeded() {
+
+        ActionBar actionBar = getActionBar();
+        if (getActionBar() != null
+                && !this.isHardwareKeyboardPresent()
+                && mHideActionBarOnSoftKeyboardUp
+                && actionBar.isShowing()) {
+            getActionBar().hide();
+        }
+    }
+
+    /**
+     * Show the action bar if needed.
+     */
+    private void showActionBarIfNeeded() {
+
+        ActionBar actionBar = getActionBar();
+        if (getActionBar() != null && !actionBar.isShowing()) {
+            getActionBar().show();
+        }
+    }
+
+    /**
+     * Returns true if a hardware keyboard is detected, otherwise false.
+     */
+    private boolean isHardwareKeyboardPresent() {
+        Configuration config = getResources().getConfiguration();
+        boolean returnValue = false;
+        if (config.keyboard != Configuration.KEYBOARD_NOKEYS) {
+            returnValue = true;
+        }
+        return returnValue;
     }
 
     void updateFormatBarEnabledState(boolean enabled) {


### PR DESCRIPTION
Fixes #173.

To test, run wpandroid with the updated editor branch:

`git subtree pull --prefix=libs/editor git@github.com:wordpress-mobile/WordPress-Editor-Android.git issue/173-inconsistent-actionbar`

Try it out on a variety of APIs as well as a large tablet.

/cc @aforcier 
