### PR TITLE
Allow WordPress formatting to be disabled

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -61,6 +61,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     private CountDownLatch mGetTitleCountDownLatch;
     private CountDownLatch mGetContentCountDownLatch;
 
+    private boolean mWordPressFormatting = true;
+
     private final Map<String, ToggleButton> mTagToggleButtonMap = new HashMap<>();
 
     public static EditorFragment newInstance(String title, String content) {
@@ -331,7 +333,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_title').getHTMLForCallback();");
+                mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_title').getHTMLForCallback("
+                        + Boolean.toString(getWordPressFormatting()) + ");");
             }
         });
 
@@ -370,7 +373,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_content').getHTMLForCallback();");
+                mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_content').getHTMLForCallback("
+                        + Boolean.toString(getWordPressFormatting()) + ");");
             }
         });
 
@@ -484,11 +488,20 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         }
     }
 
+    public boolean getWordPressFormatting() {
+        return mWordPressFormatting;
+    }
+
+    public void setWordPressFormatting(boolean enabled) {
+        mWordPressFormatting = enabled;
+    }
+
     private void updateVisualEditorFields() {
-        mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_title').setPlainText('" +
-                Utils.escapeHtml(mTitle) + "');");
-        mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_content').setHTML('" +
-                Utils.escapeHtml(mContentHtml) + "');");
+        mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_title').setPlainText('"
+                + Utils.escapeHtml(mTitle) + "');");
+        mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_content').setHTML('"
+                + Utils.escapeHtml(mContentHtml) + "', "
+                + Boolean.toString(getWordPressFormatting()) + ");");
     }
 
     /**

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -2335,21 +2335,24 @@ ZSSField.prototype.enableRightToLeftText = function(isRTL) {
 // MARK: - HTML contents
 
 ZSSField.prototype.isEmpty = function() {
-    var html = this.getHTML();
+    var html = this.getHTML(false);
     var isEmpty = (html.length == 0 || html == "<br>");
 
     return isEmpty;
 };
 
-ZSSField.prototype.getHTML = function() {
-    var html = wp.saveText(this.wrappedObject.html());
+ZSSField.prototype.getHTML = function(format) {
+    var html = this.wrappedobject.html();
+    if ( format ) {
+        html = wp.saveText(this.wrappedObject.html());
+    }
     html = ZSSEditor.removeVisualFormatting( html );
     return html;
 };
 
-ZSSField.prototype.getHTMLForCallback = function() {
+ZSSField.prototype.getHTMLForCallback = function(format) {
     var idArgument = "id=" + this.getNodeId();
-    var contentsArgument = "contents=" + this.getHTML();
+    var contentsArgument = "contents=" + this.getHTML(format);
     var joinedArguments = idArgument + defaultCallbackSeparator + contentsArgument;
     ZSSEditor.callback('callback-response-string', joinedArguments);
 };
@@ -2363,9 +2366,12 @@ ZSSField.prototype.setPlainText = function(text) {
     this.wrappedObject.text(text);
 };
 
-ZSSField.prototype.setHTML = function(html) {
+ZSSField.prototype.setHTML = function(html, format) {
     ZSSEditor.currentEditingImage = null;
-    var mutatedHTML = wp.loadText(html);
+    var mutatedHTML = html;
+    if ( format ) {
+        mutatedHTML = wp.loadText(html);
+    }
     mutatedHTML = ZSSEditor.applyVisualFormatting(mutatedHTML);
     this.wrappedObject.html(mutatedHTML);
 };


### PR DESCRIPTION
Hey there,

First of all, I want to say a big thanks for a great library! I've found this to be a useful and full featured HTML editor that beats the others I've looked at.

I would love to implement the editor in a project I'm working on, but I need to keep `<p>` tags from being stripped out. I do understand that keeping the Android editor's formatting consistent with the web app is important.

---

My proposed change is to create a new property of EditorFragment: `mWordPressFormatting`, a `boolean` variable set to `true` by default. 
- When set to `true`: the editor functions normally. 
- When set to `false`: the editor skips formatting the html content according to the rules in `wpload.js` and `wpsave.js`.

A new method is implemented into `EditorFragment`, `setWordPressFormatting(boolean enabled)` allows toggling of `mWordPressFormatting`.

---

I would love to hear what you guys think about this!

Thanks again,
Alex Crist
