### PR TITLE
Issue #203: Restore legacy editor's original format bar size

### DIFF
--- a/WordPressEditor/src/main/res/layout/fragment_edit_post_content.xml
+++ b/WordPressEditor/src/main/res/layout/fragment_edit_post_content.xml
@@ -79,7 +79,7 @@
     <LinearLayout
         android:id="@+id/format_bar"
         android:layout_width="fill_parent"
-        android:layout_height="@dimen/format_bar_height"
+        android:layout_height="@dimen/legacy_format_bar_height"
         android:layout_gravity="bottom"
         android:background="@color/legacy_format_bar_background"
         android:orientation="horizontal"
@@ -134,14 +134,14 @@
                     android:id="@+id/link"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
-                    android:minWidth="@dimen/format_bar_height"
+                    android:minWidth="@dimen/legacy_format_bar_height"
                     android:background="@drawable/legacy_format_bar_button_link_selector" />
 
                 <Button
                     android:id="@+id/more"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
-                    android:minWidth="@dimen/format_bar_height"
+                    android:minWidth="@dimen/legacy_format_bar_height"
                     android:background="@drawable/legacy_format_bar_button_more_selector" />
             </LinearLayout>
         </HorizontalScrollView>
@@ -150,7 +150,7 @@
             android:id="@+id/addPictureButton"
             android:layout_width="wrap_content"
             android:layout_height="fill_parent"
-            android:minWidth="@dimen/format_bar_height"
+            android:minWidth="@dimen/legacy_format_bar_height"
             android:background="@drawable/legacy_format_bar_button_media_selector" />
     </LinearLayout>
 

--- a/WordPressEditor/src/main/res/values/dimens.xml
+++ b/WordPressEditor/src/main/res/values/dimens.xml
@@ -29,6 +29,7 @@
 
     <dimen name="post_editor_content_side_margin">20dp</dimen>
 
+    <dimen name="legacy_format_bar_height">40dp</dimen>
     <dimen name="margin_extra_small">2dp</dimen>
     <dimen name="margin_small">4dp</dimen>
     <dimen name="margin_medium">8dp</dimen>


### PR DESCRIPTION
Fixes #203.

We've been using a shared resource for the format bar height for the new and legacy editors. A recent change increased the new editor's format bar size from `40dp` to `44dp`, and that changed the legacy editor as well.

This change gives the legacy editor its own format bar height dimen and sets it back to `40dp`.

Note: this did not affect WPAndroid, as the WPAndroid `develop` branch currently overwrites `format_bar_height` and sets it to `40dp` anyway.

cc @bummytime
