### PR TITLE
Issue #208: Make HTML mode clearer for new posts

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -138,6 +138,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         mSourceViewContent.addTextChangedListener(new HtmlStyleTextWatcher());
 
         mSourceViewTitle.setHint(mTitlePlaceholder);
+        mSourceViewContent.setHint("<p>" + mContentPlaceholder + "</p>");
 
         // -- Format bar configuration
 


### PR DESCRIPTION
Addresses #208.

Adds placeholder text to the content field in HTML mode, wrapped in `p` tags to make it obvious that the user is in HTML mode.

![208-html-mode-content-placeholder](https://cloud.githubusercontent.com/assets/9613966/8982652/588fd124-3691-11e5-90f5-19a78f085b3d.png)

cc @bummytime 
