### PR TITLE
Issue #215: Revert changes to legacy format bar buttons

### DIFF
--- a/WordPressEditor/src/main/res/layout/fragment_edit_post_content.xml
+++ b/WordPressEditor/src/main/res/layout/fragment_edit_post_content.xml
@@ -97,35 +97,35 @@
 
                 <ToggleButton
                     android:id="@+id/bold"
-                    style="@style/ToggleButton"
+                    style="@style/LegacyToggleButton"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
                     android:background="@drawable/legacy_format_bar_button_bold_selector" />
 
                 <ToggleButton
                     android:id="@+id/em"
-                    style="@style/ToggleButton"
+                    style="@style/LegacyToggleButton"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
                     android:background="@drawable/legacy_format_bar_button_italic_selector" />
 
                 <ToggleButton
                     android:id="@+id/underline"
-                    style="@style/ToggleButton"
+                    style="@style/LegacyToggleButton"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
                     android:background="@drawable/legacy_format_bar_button_underline_selector" />
 
                 <ToggleButton
                     android:id="@+id/strike"
-                    style="@style/ToggleButton"
+                    style="@style/LegacyToggleButton"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
                     android:background="@drawable/legacy_format_bar_button_strike_selector" />
 
                 <ToggleButton
                     android:id="@+id/bquote"
-                    style="@style/ToggleButton"
+                    style="@style/LegacyToggleButton"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
                     android:background="@drawable/legacy_format_bar_button_quote_selector" />

--- a/WordPressEditor/src/main/res/values/styles.xml
+++ b/WordPressEditor/src/main/res/values/styles.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
-    <style name="ToggleButton">
-        <item name="android:minWidth">@dimen/format_bar_height</item>
-        <item name="android:minHeight">@dimen/format_bar_height</item>
+    <style name="LegacyToggleButton">
+        <item name="android:minWidth">@dimen/legacy_format_bar_height</item>
+        <item name="android:minHeight">@dimen/legacy_format_bar_height</item>
         <item name="android:textOn">""</item>
         <item name="android:textOff">""</item>
     </style>


### PR DESCRIPTION
Fixes #215. Changed the legacy `ToggleButton` style to use the legacy width/height (was changed from `40dp` to `44dp` with the new editor format bar changes).

cc @bummytime
