### PR TITLE
Fix for Blockquote wrapping sibling list

### DIFF
--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -2165,8 +2165,7 @@ ZSSField.prototype.handleKeyDownEvent = function(e) {
     } else if (this.isMultiline()) {
         this.wrapCaretInParagraphIfNecessary();
 
-        // If enter was pressed to end a UL or OL, let's check to see if it
-        // was used to end the input of a list and handle it accordingly if so
+        // If enter was pressed to end a UL or OL, let's double check and handle it accordingly if so
         if (wasEnterPressed) {
             sel = window.getSelection();
             node = $(sel.anchorNode);


### PR DESCRIPTION
This PR takes a crack at Fixing #210. Here is a video of it working: 

https://cloudup.com/c0HWu_hIJ9q. 

I had to do some gymnastics to fix how lists are inserted via `execCommand`.

@aforcier would you mind starting to take a look at this. Mainly I need you to help test it out on a variety of devices and API's. Basically just test adding lists and bquotes in a bunch of different ways.

There is a known "issue" right now. When turning off a list and the caret is after a word already in a `<li>`, blockquoteing that word cause the list to be blockquoted as well. This video demonstrates it better than I can describe:

https://cloudup.com/c2aW80mp-0L

Not sure if this issue is REALLY a high priority issue, nevertheless I think this fix helps improve matters a tad.

/cc @meremagee 
