### PR TITLE
Action should hide/appear as expected in landscape

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -61,7 +61,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     private String mTitlePlaceholder = "";
     private String mContentPlaceholder = "";
 
-    private boolean mHideActionBarOnSoftKeyboardUp;
+    private boolean mIsKeyboardOpen = false;
+    private boolean mHideActionBarOnSoftKeyboardUp = false;
 
     private String mJavaScriptResult = "";
 
@@ -153,6 +154,12 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         setupFormatBarButtonMap(view);
 
         return view;
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        mIsKeyboardOpen = false;
     }
 
     @Override
@@ -372,6 +379,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         if (event.getAction() == MotionEvent.ACTION_UP) {
             // If the WebView or EditText has received a touch event, the keyboard will be displayed and the action bar
             // should hide
+            mIsKeyboardOpen = true;
             hideActionBarIfNeeded();
         }
         return false;
@@ -382,6 +390,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
      */
     @Override
     public void onImeBack() {
+        mIsKeyboardOpen = false;
         showActionBarIfNeeded();
     }
 
@@ -679,6 +688,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         if (getActionBar() != null
                 && !isHardwareKeyboardPresent()
                 && mHideActionBarOnSoftKeyboardUp
+                && mIsKeyboardOpen
                 && actionBar.isShowing()) {
             getActionBar().hide();
         }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -62,6 +62,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     private String mContentPlaceholder = "";
 
     private boolean mIsKeyboardOpen = false;
+    private boolean mEditorWasPaused = false;
     private boolean mHideActionBarOnSoftKeyboardUp = false;
 
     private String mJavaScriptResult = "";
@@ -159,7 +160,23 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     @Override
     public void onPause() {
         super.onPause();
+        mEditorWasPaused = true;
         mIsKeyboardOpen = false;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        // If the editor was previously paused and the current orientation is landscape,
+        // hide the actionbar because the keyboard is going to appear (even if it was hidden
+        // prior to being paused).
+        if (mEditorWasPaused
+                && (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE)
+                && !getResources().getBoolean(R.bool.is_large_tablet_landscape)) {
+            mIsKeyboardOpen = true;
+            mHideActionBarOnSoftKeyboardUp = true;
+            hideActionBarIfNeeded();
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #196 

This should address the inadvertent hiding of the action bar in landscape mode. I added a bool to keep track of the keyboard state...not the most elegant approach but the best we can do given the lack of a way to do it via native Android APIs.

Things to test:
- Rotate device with soft keyboard up
- Rotate device with soft keyboard down
- high and low APIs
- Large tablet (1280dp width) should not hide action bar in landscape
- The Samsung S3 (aka "Devil Phone")
- When using hardware keyboards, action bar should always be visible on all devices

/cc @aforcier 
