### PR TITLE
Feature #187: Insert media

### DIFF
--- a/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/MockEditorActivity.java
+++ b/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/MockEditorActivity.java
@@ -47,6 +47,11 @@ public class MockEditorActivity extends AppCompatActivity implements EditorFragm
     }
 
     @Override
+    public void onMediaRetryClicked(String mediaId) {
+
+    }
+
+    @Override
     public void saveMediaFile(MediaFile mediaFile) {
 
     }

--- a/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/MockEditorActivity.java
+++ b/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/MockEditorActivity.java
@@ -52,6 +52,11 @@ public class MockEditorActivity extends AppCompatActivity implements EditorFragm
     }
 
     @Override
+    public void onMediaUploadCancelClicked(String mediaId) {
+
+    }
+
+    @Override
     public void saveMediaFile(MediaFile mediaFile) {
 
     }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -262,6 +262,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         ToggleButton mediaButton = (ToggleButton) view.findViewById(R.id.format_bar_button_media);
         mTagToggleButtonMap.put(TAG_FORMAT_BAR_BUTTON_MEDIA, mediaButton);
 
+        registerForContextMenu(mediaButton);
+
         ToggleButton linkButton = (ToggleButton) view.findViewById(R.id.format_bar_button_link);
         mTagToggleButtonMap.put(TAG_FORMAT_BAR_BUTTON_LINK, linkButton);
 
@@ -323,6 +325,11 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         } else if (id == R.id.format_bar_button_media) {
             // TODO: Handle inserting media
             ((ToggleButton) v).setChecked(false);
+
+            mEditorFragmentListener.onAddMediaClicked();
+            if (isAdded()) {
+                getActivity().openContextMenu(mTagToggleButtonMap.get(TAG_FORMAT_BAR_BUTTON_MEDIA));
+            }
         } else if (id == R.id.format_bar_button_link) {
             if (!((ToggleButton) v).isChecked()) {
                 // The link button was checked when it was pressed; remove the current link

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -547,15 +547,15 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     }
 
     @Override
-    public void appendMediaFile(final MediaFile mediaFile, final String imageUrl, ImageLoader imageLoader) {
+    public void appendMediaFile(final MediaFile mediaFile, final String mediaUrl, ImageLoader imageLoader) {
         mWebView.post(new Runnable() {
             @Override
             public void run() {
-                if (URLUtil.isNetworkUrl(imageUrl)) {
-                    mWebView.execJavaScriptFromString("ZSSEditor.insertImage('" + imageUrl + "');");
+                if (URLUtil.isNetworkUrl(mediaUrl)) {
+                    mWebView.execJavaScriptFromString("ZSSEditor.insertImage('" + mediaUrl + "');");
                 } else {
                     String id = mediaFile.getMediaId();
-                    mWebView.execJavaScriptFromString("ZSSEditor.insertLocalImage(" + id + ", '" + imageUrl + "');");
+                    mWebView.execJavaScriptFromString("ZSSEditor.insertLocalImage(" + id + ", '" + mediaUrl + "');");
                     mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + id + ", " + 0 + ");");
                 }
             }
@@ -583,33 +583,34 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     }
 
     @Override
-    public void onMediaUploadSucceeded(final String id, final String remoteUrl) {
+    public void onMediaUploadSucceeded(final String mediaId, final String remoteUrl) {
         mWebView.post(new Runnable() {
             @Override
             public void run() {
-                mWebView.execJavaScriptFromString("ZSSEditor.replaceLocalImageWithRemoteImage(" + id +  ", '" +
+                mWebView.execJavaScriptFromString("ZSSEditor.replaceLocalImageWithRemoteImage(" + mediaId + ", '" +
                         remoteUrl + "');");
             }
         });
     }
 
     @Override
-    public void onMediaUploadProgress(final String id, final float progress) {
+    public void onMediaUploadProgress(final String mediaId, final float progress) {
         mWebView.post(new Runnable() {
             @Override
             public void run() {
                 String progressString = String.format("%.1f", progress);
-                mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + id + ", " + progressString + ");");
+                mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + mediaId + ", " +
+                        progressString + ");");
             }
         });
     }
 
     @Override
-    public void onMediaUploadFailed(final String id) {
+    public void onMediaUploadFailed(final String mediaId) {
         mWebView.post(new Runnable() {
             @Override
             public void run() {
-                mWebView.execJavaScriptFromString("ZSSEditor.markImageUploadFailed(" + id + ");");
+                mWebView.execJavaScriptFromString("ZSSEditor.markImageUploadFailed(" + mediaId + ");");
             }
         });
     }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -670,6 +670,12 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         });
     }
 
+    public void onMediaTapped(final String id, String url, String meta) {
+        // TODO: Check if the id is a current upload (prompt cancel option), a retried upload (call onMediaRetryClicked)
+        // or a remote file (show image options)
+
+    }
+
     public void onLinkTapped(String url, String title) {
         LinkDialogFragment linkDialogFragment = new LinkDialogFragment();
         linkDialogFragment.setTargetFragment(this, LinkDialogFragment.LINK_DIALOG_REQUEST_CODE_UPDATE);

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -17,6 +17,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
+import android.webkit.URLUtil;
 import android.webkit.WebView;
 import android.widget.ToggleButton;
 
@@ -545,7 +546,13 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
     @Override
     public void appendMediaFile(MediaFile mediaFile, String imageUrl, ImageLoader imageLoader) {
-        // TODO
+        if (URLUtil.isNetworkUrl(imageUrl)) {
+            mWebView.execJavaScriptFromString("ZSSEditor.insertImage('" + imageUrl + "');");
+        } else {
+            String mediaId = mediaFile.getMediaId();
+            mWebView.execJavaScriptFromString("ZSSEditor.insertLocalImage(" + mediaId + ", '" + imageUrl + "');");
+            mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + mediaId + ", " + 0 + ");");
+        }
     }
 
     @Override

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -591,11 +591,12 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     }
 
     @Override
-    public void onMediaUploadProgress(final String localId, final int progress) {
+    public void onMediaUploadProgress(final String localId, final float progress) {
         mWebView.post(new Runnable() {
             @Override
             public void run() {
-                mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + localId + ", " + progress + ");");
+                String progressString = String.format("%.1f", progress);
+                mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + localId + ", " + progressString + ");");
             }
         });
     }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -552,9 +552,9 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 if (URLUtil.isNetworkUrl(imageUrl)) {
                     mWebView.execJavaScriptFromString("ZSSEditor.insertImage('" + imageUrl + "');");
                 } else {
-                    String mediaId = mediaFile.getMediaId();
-                    mWebView.execJavaScriptFromString("ZSSEditor.insertLocalImage(" + mediaId + ", '" + imageUrl + "');");
-                    mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + mediaId + ", " + 0 + ");");
+                    String id = mediaFile.getMediaId();
+                    mWebView.execJavaScriptFromString("ZSSEditor.insertLocalImage(" + id + ", '" + imageUrl + "');");
+                    mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + id + ", " + 0 + ");");
                 }
             }
         });
@@ -581,32 +581,33 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     }
 
     @Override
-    public void onMediaUploadSucceeded(final String localId, final String remoteUrl) {
+    public void onMediaUploadSucceeded(final String id, final String remoteUrl) {
         mWebView.post(new Runnable() {
             @Override
             public void run() {
-                mWebView.execJavaScriptFromString("ZSSEditor.replaceLocalImageWithRemoteImage(" + localId +  ", '" + remoteUrl + "');");
+                mWebView.execJavaScriptFromString("ZSSEditor.replaceLocalImageWithRemoteImage(" + id +  ", '" +
+                        remoteUrl + "');");
             }
         });
     }
 
     @Override
-    public void onMediaUploadProgress(final String localId, final float progress) {
+    public void onMediaUploadProgress(final String id, final float progress) {
         mWebView.post(new Runnable() {
             @Override
             public void run() {
                 String progressString = String.format("%.1f", progress);
-                mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + localId + ", " + progressString + ");");
+                mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + id + ", " + progressString + ");");
             }
         });
     }
 
     @Override
-    public void onMediaUploadFailed(final String localId) {
+    public void onMediaUploadFailed(final String id) {
         mWebView.post(new Runnable() {
             @Override
             public void run() {
-                mWebView.execJavaScriptFromString("ZSSEditor.markImageUploadFailed(" + localId +  ");");
+                mWebView.execJavaScriptFromString("ZSSEditor.markImageUploadFailed(" + id + ");");
             }
         });
     }
@@ -656,7 +657,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             @Override
             public void run() {
                 if (!focusedFieldId.isEmpty()) {
-                    switch(focusedFieldId) {
+                    switch (focusedFieldId) {
                         case "zss_field_title":
                             updateFormatBarEnabledState(false);
                             break;

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -28,6 +28,7 @@ import com.android.volley.toolbox.ImageLoader;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 
@@ -326,12 +327,15 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_content').focus();");
             }
         } else if (id == R.id.format_bar_button_media) {
-            // TODO: Handle inserting media
             ((ToggleButton) v).setChecked(false);
 
-            mEditorFragmentListener.onAddMediaClicked();
-            if (isAdded()) {
-                getActivity().openContextMenu(mTagToggleButtonMap.get(TAG_FORMAT_BAR_BUTTON_MEDIA));
+            if (mSourceView.getVisibility() == View.VISIBLE) {
+                ToastUtils.showToast(getActivity(), R.string.alert_insert_image_html_mode, ToastUtils.Duration.LONG);
+            } else {
+                mEditorFragmentListener.onAddMediaClicked();
+                if (isAdded()) {
+                    getActivity().openContextMenu(mTagToggleButtonMap.get(TAG_FORMAT_BAR_BUTTON_MEDIA));
+                }
             }
         } else if (id == R.id.format_bar_button_link) {
             if (!((ToggleButton) v).isChecked()) {

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -670,10 +670,19 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         });
     }
 
-    public void onMediaTapped(final String id, String url, String meta) {
-        // TODO: Check if the id is a current upload (prompt cancel option), a retried upload (call onMediaRetryClicked)
-        // or a remote file (show image options)
+    public void onMediaTapped(final String id, String url, String meta, String uploadStatus) {
 
+        switch (uploadStatus) {
+            case "uploading":
+                // TODO: Prompt option to cancel upload
+                break;
+            case "failed":
+                // TODO: Retry media upload
+                break;
+            default:
+                // TODO: Show media options screen
+                break;
+        }
     }
 
     public void onLinkTapped(String url, String title) {

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -671,13 +671,21 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     }
 
     public void onMediaTapped(final String id, String url, String meta, String uploadStatus) {
-
         switch (uploadStatus) {
             case "uploading":
                 // TODO: Prompt option to cancel upload
                 break;
             case "failed":
-                // TODO: Retry media upload
+                // Retry media upload
+                mEditorFragmentListener.onMediaRetryClicked(id);
+
+                mWebView.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        mWebView.execJavaScriptFromString("ZSSEditor.unmarkImageUploadFailed(" + id + ");");
+                        mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + id + ", " + 0 + ");");
+                    }
+                });
                 break;
             default:
                 // TODO: Show media options screen

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -545,14 +545,19 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     }
 
     @Override
-    public void appendMediaFile(MediaFile mediaFile, String imageUrl, ImageLoader imageLoader) {
-        if (URLUtil.isNetworkUrl(imageUrl)) {
-            mWebView.execJavaScriptFromString("ZSSEditor.insertImage('" + imageUrl + "');");
-        } else {
-            String mediaId = mediaFile.getMediaId();
-            mWebView.execJavaScriptFromString("ZSSEditor.insertLocalImage(" + mediaId + ", '" + imageUrl + "');");
-            mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + mediaId + ", " + 0 + ");");
-        }
+    public void appendMediaFile(final MediaFile mediaFile, final String imageUrl, ImageLoader imageLoader) {
+        mWebView.post(new Runnable() {
+            @Override
+            public void run() {
+                if (URLUtil.isNetworkUrl(imageUrl)) {
+                    mWebView.execJavaScriptFromString("ZSSEditor.insertImage('" + imageUrl + "');");
+                } else {
+                    String mediaId = mediaFile.getMediaId();
+                    mWebView.execJavaScriptFromString("ZSSEditor.insertLocalImage(" + mediaId + ", '" + imageUrl + "');");
+                    mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + mediaId + ", " + 0 + ");");
+                }
+            }
+        });
     }
 
     @Override
@@ -576,18 +581,33 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     }
 
     @Override
-    public void onMediaUploadSucceeded(String localId, String remoteUrl) {
-        mWebView.execJavaScriptFromString("ZSSEditor.replaceLocalImageWithRemoteImage(" + localId +  ", '" + remoteUrl + "');");
+    public void onMediaUploadSucceeded(final String localId, final String remoteUrl) {
+        mWebView.post(new Runnable() {
+            @Override
+            public void run() {
+                mWebView.execJavaScriptFromString("ZSSEditor.replaceLocalImageWithRemoteImage(" + localId +  ", '" + remoteUrl + "');");
+            }
+        });
     }
 
     @Override
-    public void onMediaUploadProgress(String localId, int progress) {
-        mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + localId + ", " + progress + ");");
+    public void onMediaUploadProgress(final String localId, final int progress) {
+        mWebView.post(new Runnable() {
+            @Override
+            public void run() {
+                mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + localId + ", " + progress + ");");
+            }
+        });
     }
 
     @Override
-    public void onMediaUploadFailed(String localId) {
-        mWebView.execJavaScriptFromString("ZSSEditor.markImageUploadFailed(" + localId +  ");");
+    public void onMediaUploadFailed(final String localId) {
+        mWebView.post(new Runnable() {
+            @Override
+            public void run() {
+                mWebView.execJavaScriptFromString("ZSSEditor.markImageUploadFailed(" + localId +  ");");
+            }
+        });
     }
 
     public void onDomLoaded() {

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -36,7 +36,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 public class EditorFragment extends EditorFragmentAbstract implements View.OnClickListener, View.OnTouchListener,
-        OnJsEditorStateChangedListener, OnImeBackListener {
+        OnJsEditorStateChangedListener, OnImeBackListener, EditorMediaUploadListener {
     private static final String ARG_PARAM_TITLE = "param_title";
     private static final String ARG_PARAM_CONTENT = "param_content";
 
@@ -573,6 +573,21 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     @Override
     public void setContentPlaceholder(CharSequence placeholderText) {
         mContentPlaceholder = placeholderText.toString();
+    }
+
+    @Override
+    public void onMediaUploadSucceeded(String localId, String remoteUrl) {
+        mWebView.execJavaScriptFromString("ZSSEditor.replaceLocalImageWithRemoteImage(" + localId +  ", '" + remoteUrl + "');");
+    }
+
+    @Override
+    public void onMediaUploadProgress(String localId, int progress) {
+        mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + localId + ", " + progress + ");");
+    }
+
+    @Override
+    public void onMediaUploadFailed(String localId) {
+        mWebView.execJavaScriptFromString("ZSSEditor.markImageUploadFailed(" + localId +  ");");
     }
 
     public void onDomLoaded() {

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -100,6 +100,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
         void onSettingsClicked();
         void onAddMediaClicked();
         void onMediaRetryClicked(String mediaId);
+        void onMediaUploadCancelClicked(String mediaId);
         // TODO: remove saveMediaFile, it's currently needed for the legacy editor - we should have something like
         // "EditorFragmentAbstract.getFeaturedImage()" returning the remote id
         void saveMediaFile(MediaFile mediaFile);

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -96,11 +96,12 @@ public abstract class EditorFragmentAbstract extends Fragment {
      * Callbacks used to communicate with the parent Activity
      */
     public interface EditorFragmentListener {
-        public void onEditorFragmentInitialized();
-        public void onSettingsClicked();
-        public void onAddMediaClicked();
+        void onEditorFragmentInitialized();
+        void onSettingsClicked();
+        void onAddMediaClicked();
+        void onMediaRetryClicked(String mediaId);
         // TODO: remove saveMediaFile, it's currently needed for the legacy editor - we should have something like
         // "EditorFragmentAbstract.getFeaturedImage()" returning the remote id
-        public void saveMediaFile(MediaFile mediaFile);
+        void saveMediaFile(MediaFile mediaFile);
     }
 }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUploadListener.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUploadListener.java
@@ -1,0 +1,7 @@
+package org.wordpress.android.editor;
+
+public interface EditorMediaUploadListener {
+    void onMediaUploadSucceeded(String localId, String remoteUrl);
+    void onMediaUploadProgress(String localId, int progress);
+    void onMediaUploadFailed(String localId);
+}

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUploadListener.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUploadListener.java
@@ -2,6 +2,6 @@ package org.wordpress.android.editor;
 
 public interface EditorMediaUploadListener {
     void onMediaUploadSucceeded(String localId, String remoteUrl);
-    void onMediaUploadProgress(String localId, int progress);
+    void onMediaUploadProgress(String localId, float progress);
     void onMediaUploadFailed(String localId);
 }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/JsCallbackReceiver.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/JsCallbackReceiver.java
@@ -2,7 +2,10 @@ package org.wordpress.android.editor;
 
 import android.webkit.JavascriptInterface;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.JSONUtils;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -112,7 +115,22 @@ public class JsCallbackReceiver {
                     mediaMeta = Utils.decodeHtml(mediaMeta);
                 }
 
-                mListener.onMediaTapped(mediaId, mediaUrl, mediaMeta);
+                String uploadStatus = "";
+                try {
+                    String classes = JSONUtils.getString(new JSONObject(mediaMeta), "classes");
+                    Set<String> classesSet = Utils.splitDelimitedString(classes, ", ");
+
+                    if (classesSet.contains("uploading")) {
+                        uploadStatus = "uploading";
+                    } else if (classesSet.contains("failed")) {
+                        uploadStatus = "failed";
+                    }
+                } catch (JSONException e) {
+                    e.printStackTrace();
+                    AppLog.d(AppLog.T.EDITOR, "Media meta data from callback-image-tap was not JSON-formatted");
+                }
+
+                mListener.onMediaTapped(mediaId, mediaUrl, mediaMeta, uploadStatus);
                 break;
             case CALLBACK_LINK_TAP:
                 // Extract and HTML-decode the link data from the callback params

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/JsCallbackReceiver.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/JsCallbackReceiver.java
@@ -95,6 +95,8 @@ public class JsCallbackReceiver {
             case CALLBACK_IMAGE_TAP:
                 AppLog.d(AppLog.T.EDITOR, "Image tapped, " + params);
 
+                String uploadStatus = "";
+
                 List<String> mediaIds = new ArrayList<>();
                 mediaIds.add("id");
                 mediaIds.add("url");
@@ -113,21 +115,20 @@ public class JsCallbackReceiver {
                 String mediaMeta = mediaDataMap.get("meta");
                 if (mediaMeta != null) {
                     mediaMeta = Utils.decodeHtml(mediaMeta);
-                }
 
-                String uploadStatus = "";
-                try {
-                    String classes = JSONUtils.getString(new JSONObject(mediaMeta), "classes");
-                    Set<String> classesSet = Utils.splitDelimitedString(classes, ", ");
+                    try {
+                        String classes = JSONUtils.getString(new JSONObject(mediaMeta), "classes");
+                        Set<String> classesSet = Utils.splitDelimitedString(classes, ", ");
 
-                    if (classesSet.contains("uploading")) {
-                        uploadStatus = "uploading";
-                    } else if (classesSet.contains("failed")) {
-                        uploadStatus = "failed";
+                        if (classesSet.contains("uploading")) {
+                            uploadStatus = "uploading";
+                        } else if (classesSet.contains("failed")) {
+                            uploadStatus = "failed";
+                        }
+                    } catch (JSONException e) {
+                        e.printStackTrace();
+                        AppLog.d(AppLog.T.EDITOR, "Media meta data from callback-image-tap was not JSON-formatted");
                     }
-                } catch (JSONException e) {
-                    e.printStackTrace();
-                    AppLog.d(AppLog.T.EDITOR, "Media meta data from callback-image-tap was not JSON-formatted");
                 }
 
                 mListener.onMediaTapped(mediaId, mediaUrl, mediaMeta, uploadStatus);

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/JsCallbackReceiver.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/JsCallbackReceiver.java
@@ -90,8 +90,29 @@ public class JsCallbackReceiver {
                 AppLog.d(AppLog.T.EDITOR, "Image replaced, " + params);
                 break;
             case CALLBACK_IMAGE_TAP:
-                // TODO: Notifies that an image was tapped
                 AppLog.d(AppLog.T.EDITOR, "Image tapped, " + params);
+
+                List<String> mediaIds = new ArrayList<>();
+                mediaIds.add("id");
+                mediaIds.add("url");
+                mediaIds.add("meta");
+
+                Set<String> mediaDataSet = Utils.splitValuePairDelimitedString(params, JS_CALLBACK_DELIMITER, mediaIds);
+                Map<String, String> mediaDataMap = Utils.buildMapFromKeyValuePairs(mediaDataSet);
+
+                String mediaId = mediaDataMap.get("id");
+
+                String mediaUrl = mediaDataMap.get("url");
+                if (mediaUrl != null) {
+                    mediaUrl = Utils.decodeHtml(mediaUrl);
+                }
+
+                String mediaMeta = mediaDataMap.get("meta");
+                if (mediaMeta != null) {
+                    mediaMeta = Utils.decodeHtml(mediaMeta);
+                }
+
+                mListener.onMediaTapped(mediaId, mediaUrl, mediaMeta);
                 break;
             case CALLBACK_LINK_TAP:
                 // Extract and HTML-decode the link data from the callback params

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/OnJsEditorStateChangedListener.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/OnJsEditorStateChangedListener.java
@@ -6,6 +6,7 @@ public interface OnJsEditorStateChangedListener {
     void onDomLoaded();
     void onSelectionChanged(Map<String, String> selectionArgs);
     void onSelectionStyleChanged(Map<String, Boolean> changeSet);
+    void onMediaTapped(String mediaId, String url, String meta);
     void onLinkTapped(String url, String title);
     void onGetHtmlResponse(Map<String, String> responseArgs);
 }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/OnJsEditorStateChangedListener.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/OnJsEditorStateChangedListener.java
@@ -6,7 +6,7 @@ public interface OnJsEditorStateChangedListener {
     void onDomLoaded();
     void onSelectionChanged(Map<String, String> selectionArgs);
     void onSelectionStyleChanged(Map<String, Boolean> changeSet);
-    void onMediaTapped(String mediaId, String url, String meta);
+    void onMediaTapped(String mediaId, String url, String meta, String uploadStatus);
     void onLinkTapped(String url, String title);
     void onGetHtmlResponse(Map<String, String> responseArgs);
 }

--- a/WordPressEditor/src/main/res/values/strings.xml
+++ b/WordPressEditor/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="delete">Delete</string>
 
     <string name="alert_insert_image_html_mode">Can\'t insert images directly in HTML mode. Please switch back to visual mode.</string>
+    <string name="alert_html_toggle_uploading">You are currently uploading media. Please wait until this completes.</string>
 
     <string name="stop_upload_dialog_title">Stop uploading?</string>
     <string name="stop_upload_button">Stop Upload</string>

--- a/WordPressEditor/src/main/res/values/strings.xml
+++ b/WordPressEditor/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="cancel">Cancel</string>
     <string name="delete">Delete</string>
 
-    <string name="alert_insert_image_html_mode">Can\'t insert images directly in HTML mode. Please switch back to visual mode.</string>
+    <string name="alert_insert_image_html_mode">Can\'t insert media directly in HTML mode. Please switch back to visual mode.</string>
     <string name="alert_html_toggle_uploading">You are currently uploading media. Please wait until this completes.</string>
 
     <string name="stop_upload_dialog_title">Stop uploading?</string>

--- a/WordPressEditor/src/main/res/values/strings.xml
+++ b/WordPressEditor/src/main/res/values/strings.xml
@@ -8,6 +8,8 @@
     <string name="cancel">Cancel</string>
     <string name="delete">Delete</string>
 
+    <string name="alert_insert_image_html_mode">Can\'t insert images directly in HTML mode. Please switch back to visual mode.</string>
+
     <string name="stop_upload_dialog_title">Stop uploading?</string>
     <string name="stop_upload_button">Stop Upload</string>
 

--- a/WordPressEditor/src/main/res/values/strings.xml
+++ b/WordPressEditor/src/main/res/values/strings.xml
@@ -8,6 +8,9 @@
     <string name="cancel">Cancel</string>
     <string name="delete">Delete</string>
 
+    <string name="stop_upload_dialog_title">Stop uploading?</string>
+    <string name="stop_upload_button">Stop Upload</string>
+
     <string name="format_bar_tag_bold" translatable="false">bold</string>
     <string name="format_bar_tag_italic" translatable="false">italic</string>
     <string name="format_bar_tag_blockquote" translatable="false">blockquote</string>

--- a/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
+++ b/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
@@ -139,6 +139,11 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
     }
 
     @Override
+    public void onMediaUploadCancelClicked(String mediaId) {
+
+    }
+
+    @Override
     public void onEditorFragmentInitialized() {
         // arbitrary setup
         mEditorFragment.setFeaturedImageSupported(true);

--- a/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
+++ b/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
@@ -125,6 +125,10 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
     }
 
     @Override
+    public void onMediaRetryClicked(String mediaId) {
+    }
+
+    @Override
     public void onEditorFragmentInitialized() {
         // arbitrary setup
         mEditorFragment.setFeaturedImageSupported(true);

--- a/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
+++ b/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
@@ -15,6 +15,9 @@ import org.wordpress.android.editor.EditorMediaUploadListener;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class EditorExampleActivity extends AppCompatActivity implements EditorFragmentListener {
     public static final String EDITOR_PARAM = "EDITOR_PARAM";
     public static final String TITLE_PARAM = "TITLE_PARAM";
@@ -33,6 +36,8 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
 
     private EditorFragmentAbstract mEditorFragment;
 
+    private Map<String, String> mFailedUploads;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -43,6 +48,8 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
             ToastUtils.showToast(this, R.string.starting_legacy_editor);
             setContentView(R.layout.activity_legacy_editor);
         }
+
+        mFailedUploads = new HashMap<>();
     }
 
     @Override
@@ -126,6 +133,9 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
 
     @Override
     public void onMediaRetryClicked(String mediaId) {
+        if (mFailedUploads.containsKey(mediaId)) {
+            simulateFileUpload(mediaId, mFailedUploads.get(mediaId));
+        }
     }
 
     @Override
@@ -165,6 +175,10 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
                     }
 
                     ((EditorMediaUploadListener) mEditorFragment).onMediaUploadSucceeded(mediaId, mediaUrl);
+
+                    if (mFailedUploads.containsKey(mediaId)) {
+                        mFailedUploads.remove(mediaId);
+                    }
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }
@@ -189,6 +203,8 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
                     }
 
                     ((EditorMediaUploadListener) mEditorFragment).onMediaUploadFailed(mediaId);
+
+                    mFailedUploads.put(mediaId, mediaUrl);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -12,4 +12,7 @@
     <string name="example_post_2_content">
         <![CDATA[<p>Post 2 Content</p><blockquote>Quoted text</blockquote><br/>]]>
     </string>
+
+    <string name="select_photo">Select a photo</string>
+    <string name="select_photo_fail">Select a photo (failure demo)</string>
 </resources>

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -822,7 +822,9 @@ ZSSEditor.insertImage = function(url, alt) {
  *                                      does not check for that.  It would be a mistake.
  */
 ZSSEditor.insertLocalImage = function(imageNodeIdentifier, localImageUrl) {
-    var space = '&nbsp';
+    var space = '<br>';
+    var paragraphOpenTag = '<' + this.defaultParagraphSeparator + '>';
+    var paragraphCloseTag = '</' + this.defaultParagraphSeparator + '>';
     var progressIdentifier = this.getImageProgressIdentifier(imageNodeIdentifier);
     var imageContainerIdentifier = this.getImageContainerIdentifier(imageNodeIdentifier);
     var imgContainerStart = '<span id="' + imageContainerIdentifier+'" class="img_container" contenteditable="false" data-failed="Tap to try again!">';
@@ -830,7 +832,11 @@ ZSSEditor.insertLocalImage = function(imageNodeIdentifier, localImageUrl) {
     var progress = '<progress id="' + progressIdentifier+'" value=0  class="wp_media_indicator"  contenteditable="false"></progress>';
     var image = '<img data-wpid="' + imageNodeIdentifier + '" src="' + localImageUrl + '" alt="" />';
     var html = imgContainerStart + progress+image + imgContainerEnd;
-    html = space + html + space;
+
+    if (this.getFocusedField().getHTML().length == 0) {
+        html = paragraphOpenTag + html;
+    }
+    html = html + paragraphCloseTag + paragraphOpenTag + space;
 
     this.insertHTML(html);
     this.sendEnabledStyles();

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -802,7 +802,16 @@ ZSSEditor.updateImage = function(url, alt) {
 };
 
 ZSSEditor.insertImage = function(url, alt) {
-    var html = '<img src="'+url+'" alt="'+alt+'" />';
+    var space = '<br>';
+    var paragraphOpenTag = '<' + this.defaultParagraphSeparator + '>';
+    var paragraphCloseTag = '</' + this.defaultParagraphSeparator + '>';
+
+    var html = '<img src="' + url + '" alt="' + alt + '" />';
+
+    if (this.getFocusedField().getHTML().length == 0) {
+        html = paragraphOpenTag + html;
+    }
+    html = html + paragraphCloseTag + paragraphOpenTag + space;
 
     this.insertHTML(html);
     this.sendEnabledStyles();


### PR DESCRIPTION
Addresses #187. Adds basic support for inserting images into the visual editor. Doesn't include editing image settings - that will be addressed in a separate PR (issue #13).

This PR also adds some demo functionality to the example app, to simulate handling uploads and making appropriate calls back to the editor fragment. Integration with WPAndroid will be introduced in a future PR.

![187-media-uploading](https://cloud.githubusercontent.com/assets/9613966/9488177/a56a2530-4be0-11e5-9540-d4bdd4c55a88.png)

Tapping an uploading image shows a prompt allowing the user to cancel the upload:

![187-media-stop-upload-dialog](https://cloud.githubusercontent.com/assets/9613966/9488165/90315b7a-4be0-11e5-8e1d-e583dfb57b53.png)

An overlay is shown when an upload fails. Tapping the image in this state restarts the upload:

![187-media-upload-fail-overlay](https://cloud.githubusercontent.com/assets/9613966/9488169/97196c5c-4be0-11e5-8d86-0e15810089ed.png)

HTML mode is disabled during upload

![187-media-upload-html-toast](https://cloud.githubusercontent.com/assets/9613966/9488175/9f312a4c-4be0-11e5-946f-23ffbd591d6e.png)

<h2>Known issues:</h2>


<h3>1: Samsung S3 image spacing issue</h3>


There is currently a bug occurring on the Samsung S3 (`API 18`). It ignores the space and you're stuck with the cursor on the left side of the image - no way to keep typing under the image without going into HTML mode. This didn't happen on emulators (`API 14-22`), but I trust physical devices more - we might need some testing on older devices to figure out the extent of the issue.

The S3 issue can be fixed by using a zero-width space character (`U+200B`) instead of `<br>` as a separator [here](https://github.com/wordpress-mobile/WordPress-Editor-Android/blob/ddb5454bd7a6a932eaf0bbb5ea0ddb531a16233b/libs/editor-common/assets/ZSSRichTextEditor.js#L834). This works on all devices, but messes up autocorrect - the ZW space character is treated as a real character, so the keyboard switches to lowercase under the image (as if a sentence had already started). There might be a different solution for the spacing that will work everywhere with no issues, or we might be able to force the autocapitalization back on after images.

<h3>2: Missing upload progress bar (API < 19)</h3>


On all `API < 19` devices, the progress bar doesn't show up when uploading images. It seems that Android didn't support the `<progress>` tag we're using until the Chromium WebView (`API 19`).  One possibility here is to use an upload notification instead. The WPAndroid app uses those for post uploads and gallery uploads, so we might want to use it for individual image uploads anyway (on all APIs, even ones where the progress bar inside the WebView is shown). Here's a demo of what that would look like on an API 18 device (the notification isn't included in this PR, just looking for feedback):

https://cloudup.com/cqzRAsg_CeE

<h3>3: Uploading image container is sometimes very small (API < 19)</h3>


Sometimes (probably when uploading media in a blank document, still testing) the image container is very small while uploading. Once the container is removed at the end of the upload, the normal-sized image is shown:

https://cloudup.com/c2HhsInzXsW

The problem is resolved by removing [this](https://github.com/wordpress-mobile/WordPress-Editor-Android/blob/244a51315e24eddc0510b422a75e6483c6c0f6f3/libs/editor-common/assets/editor.css#L141) line from the CSS. However, this probably isn't the root cause, and it also breaks the progress bar on `API > 18`.

If we can't fix issue #2 above, we might as well drop the container entirely (and load a different CSS file for API > 18`and for`API <= 18`).

<h3>4: Bugginess with the edit overlay on some API levels</h3>


I'll address this one as part of the future PR for #13.
