### PR TITLE
Issue #234: Upgrade Robolectric to 3.0

### DIFF
--- a/WordPressEditor/build.gradle
+++ b/WordPressEditor/build.gradle
@@ -4,12 +4,10 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.2.3'
-        classpath 'org.robolectric:robolectric-gradle-plugin:1.1.0'
     }
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'org.robolectric'
 apply plugin: 'jacoco'
 apply plugin: 'maven'
 apply plugin: 'signing'
@@ -56,13 +54,12 @@ dependencies {
     // Test libraries
     testCompile 'junit:junit:4.11'
     testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'org.robolectric:robolectric:2.4'
+    testCompile 'org.robolectric:robolectric:3.0'
 
     // Workaround for IDE bug
     // http://stackoverflow.com/questions/22246183/android-studio-doesnt-recognize-espresso-classes
     provided 'junit:junit:4.11'
     provided 'org.mockito:mockito-core:1.10.19'
-    provided 'org.robolectric:robolectric:2.4'
 }
 
 signing {

--- a/WordPressEditor/src/test/java/org/wordpress/android/editor/EditorFragmentAbstractTest.java
+++ b/WordPressEditor/src/test/java/org/wordpress/android/editor/EditorFragmentAbstractTest.java
@@ -14,7 +14,7 @@ import org.robolectric.annotation.Config;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 
-@Config(emulateSdk = 18)
+@Config(sdk = 18)
 @RunWith(RobolectricTestRunner.class)
 public class EditorFragmentAbstractTest {
     @Test

--- a/WordPressEditor/src/test/java/org/wordpress/android/editor/HtmlStyleTextWatcherTest.java
+++ b/WordPressEditor/src/test/java/org/wordpress/android/editor/HtmlStyleTextWatcherTest.java
@@ -15,7 +15,7 @@ import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 
-@Config(emulateSdk = 18)
+@Config(sdk = 18)
 @RunWith(RobolectricTestRunner.class)
 public class HtmlStyleTextWatcherTest {
 

--- a/WordPressEditor/src/test/java/org/wordpress/android/editor/HtmlStyleUtilsTest.java
+++ b/WordPressEditor/src/test/java/org/wordpress/android/editor/HtmlStyleUtilsTest.java
@@ -16,7 +16,7 @@ import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 
-@Config(emulateSdk = 18)
+@Config(sdk = 18)
 @RunWith(RobolectricTestRunner.class)
 public class HtmlStyleUtilsTest {
 

--- a/WordPressEditor/src/test/java/org/wordpress/android/editor/JsCallbackReceiverTest.java
+++ b/WordPressEditor/src/test/java/org/wordpress/android/editor/JsCallbackReceiverTest.java
@@ -17,7 +17,7 @@ import static junit.framework.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.robolectric.shadows.ShadowLog.LogItem;
 
-@Config(emulateSdk = 18)
+@Config(sdk = 18)
 @RunWith(RobolectricTestRunner.class)
 public class JsCallbackReceiverTest {
     private final static String EDITOR_LOG_TAG = "WordPress-" + AppLog.T.EDITOR.toString();

--- a/WordPressEditor/src/test/java/org/wordpress/android/editor/UtilsTest.java
+++ b/WordPressEditor/src/test/java/org/wordpress/android/editor/UtilsTest.java
@@ -21,7 +21,7 @@ import static org.wordpress.android.editor.Utils.getChangeMapFromSets;
 import static org.wordpress.android.editor.Utils.splitDelimitedString;
 import static org.wordpress.android.editor.Utils.splitValuePairDelimitedString;
 
-@Config(emulateSdk = 18)
+@Config(sdk = 18)
 @RunWith(RobolectricTestRunner.class)
 public class UtilsTest {
 


### PR DESCRIPTION
Fixes #234. Upgrades to Robolectric `3.0`, and drops the now-obsolete `robolectric-gradle-plugin`.

cc @bummytime
