### PR TITLE
Issue #245: Upgrade gradle to 1.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ android:
   components:
     - extra-android-m2repository
     - extra-android-support
-    - build-tools-22.0.1
-    - android-22
+    - build-tools-23.0.1
+    - android-23
 
 env:
   global:

--- a/WordPressEditor/build.gradle
+++ b/WordPressEditor/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.3.1'
     }
 }
 
@@ -13,20 +13,20 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 repositories {
-    mavenCentral()
+    jcenter()
 }
 
 android {
     publishNonDefault true
 
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         versionCode 3
         versionName "0.3"
         minSdkVersion 14
-        targetSdkVersion 22
+        targetSdkVersion 23
     }
     buildTypes {
         release {
@@ -46,8 +46,8 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:22.2.0'
-    compile 'com.android.support:support-v4:22.2.0'
+    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:support-v4:23.0.1'
     compile 'org.wordpress:analytics:1.0.0'
     compile 'org.wordpress:utils:1.6.0'
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,26 +1,26 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.3.1'
     }
 }
 
 repositories {
-    mavenCentral()
+    jcenter()
 }
 
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         applicationId "org.wordpress.editorexample"
         minSdkVersion 14
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Addresses issue #245.

Updates gradle plugin, target SDK, and support libraries to the latest versions (Android `API 23`), syncing up with the main WPAndroid project.
