### PR TITLE
Issue #243: Persist post when connecting hardware keyboard

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -47,6 +47,9 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
     private static final String JS_CALLBACK_HANDLER = "nativeCallbackHandler";
 
+    private static final String KEY_TITLE = "title";
+    private static final String KEY_CONTENT = "content";
+
     private static final String TAG_FORMAT_BAR_BUTTON_MEDIA = "media";
     private static final String TAG_FORMAT_BAR_BUTTON_LINK = "link";
 
@@ -135,6 +138,11 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
         initJsEditor();
 
+        if (savedInstanceState != null) {
+            setTitle(savedInstanceState.getCharSequence(KEY_TITLE));
+            setContent(savedInstanceState.getCharSequence(KEY_CONTENT));
+        }
+
         // -- HTML mode configuration
 
         mSourceView = view.findViewById(R.id.sourceview);
@@ -192,6 +200,12 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     @Override
     public void onDetach() {
         super.onDetach();
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        outState.putCharSequence(KEY_TITLE, getTitle());
+        outState.putCharSequence(KEY_CONTENT, getContent());
     }
 
     private ActionBar getActionBar() {


### PR DESCRIPTION
Fixes #243.

The issue was caused by the activity being recreated when the software keyboard is disabled or enabled (caused when connecting and disconnecting a hardware keyboard, respectively). Under those circumstances, the title and content weren't being saved.

Fixed by storing the title and content with `onSaveInstanceState()` and restoring them when the activity is re-created.
