### PR TITLE
Issue #233: Sharing content to the editor from other apps

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -606,7 +606,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             return "";
         }
 
-        if (mSourceView.getVisibility() == View.VISIBLE) {
+        if (mSourceView != null && mSourceView.getVisibility() == View.VISIBLE) {
             mTitle = mSourceViewTitle.getText().toString();
             return StringUtils.notNullStr(mTitle);
         }
@@ -645,7 +645,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             return "";
         }
 
-        if (mSourceView.getVisibility() == View.VISIBLE) {
+        if (mSourceView != null && mSourceView.getVisibility() == View.VISIBLE) {
             mContentHtml = mSourceViewContent.getText().toString();
             return StringUtils.notNullStr(mContentHtml);
         }


### PR DESCRIPTION
Fixes #233. Adds support for sharing media from other apps.

To test, `subtree pull` this branch into a local copy of WPAndroid's `feature/visual-editor`.

Test sharing single and multiple images, as well as chunks of text to WPAndroid from another app.

cc @bummytime
