### PR TITLE
Issue #261: Image settings screen navigation fixes

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -96,8 +96,12 @@ public class ImageSettingsDialogFragment extends DialogFragment {
             public void onClick(View v) {
                 mImageMeta = extractMetaDataFromFields(mImageMeta);
 
-
-                imageRemoteId = mImageMeta.getString("attachment_id");
+                String imageRemoteId = "";
+                try {
+                    imageRemoteId = mImageMeta.getString("attachment_id");
+                } catch (JSONException e) {
+                    AppLog.e(AppLog.T.EDITOR, "Unable to retrieve featured image id from meta data");
+                }
 
                 Intent intent = new Intent();
                 intent.putExtra("imageMeta", mImageMeta.toString());

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -31,6 +31,12 @@ import org.wordpress.android.util.AppLog;
 
 import java.util.Arrays;
 
+/**
+ * A full-screen DialogFragment with image settings.
+ *
+ * Modifies the action bar - host activity must call {@link ImageSettingsDialogFragment#dismissFragment()}
+ * when the fragment is dismissed to restore it.
+ */
 public class ImageSettingsDialogFragment extends DialogFragment {
 
     public static final int IMAGE_SETTINGS_DIALOG_REQUEST_CODE = 5;
@@ -174,25 +180,7 @@ public class ImageSettingsDialogFragment extends DialogFragment {
         int id = item.getItemId();
 
         if (id == android.R.id.home) {
-            try {
-                JSONObject newImageMeta = extractMetaDataFromFields(new JSONObject());
-
-                for (int i = 0; i < newImageMeta.names().length(); i++) {
-                    String name = newImageMeta.names().getString(i);
-                    if (!newImageMeta.getString(name).equals(mImageMeta.getString(name))) {
-                        showDiscardChangesDialog();
-                        return true;
-                    }
-                }
-
-                // TODO: Also check if featured image status has changed once it's supported
-
-            } catch (JSONException e) {
-                AppLog.d(AppLog.T.EDITOR, "Unable to update JSON array");
-            }
-
-            restorePreviousActionBar();
-            getFragmentManager().popBackStack();
+            dismissFragment();
             return true;
         }
         return super.onOptionsItemSelected(item);
@@ -208,6 +196,34 @@ public class ImageSettingsDialogFragment extends DialogFragment {
         } else {
             return null;
         }
+    }
+
+    /**
+     * To be called when the fragment is being dismissed, either by ActionBar navigation or by pressing back in the
+     * navigation bar.
+     * Displays a confirmation dialog if there are unsaved changes, otherwise undoes the fragment's modifications to
+     * the ActionBar and restores the last visible fragment.
+     */
+    public void dismissFragment() {
+        try {
+            JSONObject newImageMeta = extractMetaDataFromFields(new JSONObject());
+
+            for (int i = 0; i < newImageMeta.names().length(); i++) {
+                String name = newImageMeta.names().getString(i);
+                if (!newImageMeta.getString(name).equals(mImageMeta.getString(name))) {
+                    showDiscardChangesDialog();
+                    return;
+                }
+            }
+
+            // TODO: Also check if featured image status has changed once it's supported
+
+        } catch (JSONException e) {
+            AppLog.d(AppLog.T.EDITOR, "Unable to update JSON array");
+        }
+
+        restorePreviousActionBar();
+        getFragmentManager().popBackStack();
     }
 
     private void restorePreviousActionBar() {

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -57,6 +57,8 @@ public class ImageSettingsDialogFragment extends DialogFragment {
     private EditText mWidthText;
     private CheckBox mFeaturedCheckBox;
 
+    private boolean mIsFeatured;
+
     private CharSequence mPreviousActionBarTitle;
     private boolean mPreviousHomeAsUpEnabled;
     private View mPreviousCustomView;
@@ -106,8 +108,8 @@ public class ImageSettingsDialogFragment extends DialogFragment {
                 Intent intent = new Intent();
                 intent.putExtra("imageMeta", mImageMeta.toString());
 
-                boolean isFeaturedImage = mFeaturedCheckBox.isChecked();
-                intent.putExtra("isFeatured", isFeaturedImage);
+                mIsFeatured = mFeaturedCheckBox.isChecked();
+                intent.putExtra("isFeatured", mIsFeatured);
 
                 if (!imageRemoteId.isEmpty()) {
                     intent.putExtra("imageRemoteId", Integer.parseInt(imageRemoteId));
@@ -170,7 +172,8 @@ public class ImageSettingsDialogFragment extends DialogFragment {
                 boolean featuredImageSupported = bundle.getBoolean("featuredImageSupported");
                 if (featuredImageSupported) {
                     mFeaturedCheckBox.setVisibility(View.VISIBLE);
-                    mFeaturedCheckBox.setChecked(bundle.getBoolean("isFeatured", false));
+                    mIsFeatured = bundle.getBoolean("isFeatured", false);
+                    mFeaturedCheckBox.setChecked(mIsFeatured);
                 }
 
             } catch (JSONException e1) {
@@ -239,8 +242,11 @@ public class ImageSettingsDialogFragment extends DialogFragment {
                 }
             }
 
-            // TODO: Also check if featured image status has changed once it's supported
-
+            if (mFeaturedCheckBox.isChecked() != mIsFeatured) {
+                // Featured image status has changed
+                showDiscardChangesDialog();
+                return;
+            }
         } catch (JSONException e) {
             AppLog.d(AppLog.T.EDITOR, "Unable to update JSON array");
         }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -255,7 +255,7 @@ public class ImageSettingsDialogFragment extends DialogFragment {
             metaData.put("title", mTitleText.getText().toString());
             metaData.put("caption", mCaptionText.getText().toString());
             metaData.put("alt", mAltText.getText().toString());
-            metaData.put("align", mAlignmentSpinner.getSelectedItem().toString());
+            metaData.put("align", mAlignmentSpinner.getSelectedItem().toString().toLowerCase());
             metaData.put("linkUrl", mLinkTo.getText().toString());
 
             int newWidth = getEditTextIntegerClamped(mWidthText, 10, mMaxImageWidth);

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -30,6 +30,7 @@ import org.json.JSONObject;
 import org.wordpress.android.util.AppLog;
 
 import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * A full-screen DialogFragment with image settings.
@@ -139,6 +140,10 @@ public class ImageSettingsDialogFragment extends DialogFragment {
                 mAltText.setText(mImageMeta.getString("alt"));
 
                 String alignment = mImageMeta.getString("align");
+
+                // Capitalize the alignment value to match the spinner entries
+                alignment = alignment.substring(0, 1).toUpperCase(Locale.US) + alignment.substring(1);
+
                 String[] alignmentArray = getResources().getStringArray(R.array.alignment_array);
                 mAlignmentSpinner.setSelection(Arrays.asList(alignmentArray).indexOf(alignment));
 
@@ -271,7 +276,7 @@ public class ImageSettingsDialogFragment extends DialogFragment {
             metaData.put("title", mTitleText.getText().toString());
             metaData.put("caption", mCaptionText.getText().toString());
             metaData.put("alt", mAltText.getText().toString());
-            metaData.put("align", mAlignmentSpinner.getSelectedItem().toString().toLowerCase());
+            metaData.put("align", mAlignmentSpinner.getSelectedItem().toString().toLowerCase(Locale.US));
             metaData.put("linkUrl", mLinkTo.getText().toString());
 
             int newWidth = getEditTextIntegerClamped(mWidthText, 10, mMaxImageWidth);

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -28,6 +28,7 @@ import android.widget.TextView;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.ToastUtils;
 
 import java.util.Arrays;
 import java.util.Locale;
@@ -103,6 +104,7 @@ public class ImageSettingsDialogFragment extends DialogFragment {
 
                 restorePreviousActionBar();
                 getFragmentManager().popBackStack();
+                ToastUtils.showToast(getActivity(), R.string.image_settings_save_toast);
             }
         });
     }

--- a/WordPressEditor/src/main/res/values/strings.xml
+++ b/WordPressEditor/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="cancel">Cancel</string>
     <string name="delete">Delete</string>
     <string name="save">Save</string>
+    <string name="discard">Discard</string>
 
     <string name="alert_insert_image_html_mode">Can\'t insert media directly in HTML mode. Please switch back to visual mode.</string>
     <string name="alert_html_toggle_uploading">You are currently uploading media. Please wait until this completes.</string>
@@ -37,6 +38,8 @@
     <string name="image_alignment">Alignment</string>
     <string name="horizontal_alignment">Horizontal alignment</string>
     <string name="caption">Caption (optional)</string>
+
+    <string name="image_settings_dismiss_dialog_title">Discard unsaved changes?</string>
 
     <string name="image_caption">Caption</string>
     <string name="image_alt_text">Alt text</string>

--- a/WordPressEditor/src/main/res/values/strings.xml
+++ b/WordPressEditor/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="caption">Caption (optional)</string>
 
     <string name="image_settings_dismiss_dialog_title">Discard unsaved changes?</string>
+    <string name="image_settings_save_toast">Changes saved</string>
 
     <string name="image_caption">Caption</string>
     <string name="image_alt_text">Alt text</string>

--- a/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
+++ b/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
@@ -12,6 +12,7 @@ import android.view.View;
 import org.wordpress.android.editor.EditorFragmentAbstract;
 import org.wordpress.android.editor.EditorFragmentAbstract.EditorFragmentListener;
 import org.wordpress.android.editor.EditorMediaUploadListener;
+import org.wordpress.android.editor.ImageSettingsDialogFragment;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 
@@ -57,6 +58,17 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
         super.onAttachFragment(fragment);
         if (fragment instanceof EditorFragmentAbstract) {
             mEditorFragment = (EditorFragmentAbstract) fragment;
+        }
+    }
+
+    @Override
+    public void onBackPressed() {
+        Fragment fragment =  getFragmentManager()
+                .findFragmentByTag(ImageSettingsDialogFragment.IMAGE_SETTINGS_DIALOG_TAG);
+        if (fragment != null && fragment.isVisible()) {
+            ((ImageSettingsDialogFragment) fragment).dismissFragment();
+        } else {
+            super.onBackPressed();
         }
     }
 


### PR DESCRIPTION
Fixes #261, making a few improvements to navigating away from the image settings dialog.
- Tapping the device back button now returns the user to the editor (instead of exiting the editor entirely), making it the same as pressing the home button in the ActionBar
- Show a confirmation dialog when closing the settings dialog with unsaved changes:

![261-image-settings-nav-dialog](https://cloud.githubusercontent.com/assets/9613966/11384159/7dddaf4a-92db-11e5-8545-3f1992a4bd8a.png)
- Show a toast that changes have been saved when the Save button is pressed in the ActionBar:

![261-image-settings-nav-saved-toast](https://cloud.githubusercontent.com/assets/9613966/11384161/8306092c-92db-11e5-8d57-506f0e644492.png)
- Also incorporates checking for changes to featured images, which were introduced in #266

Demo of all the changes, on WPAndroid: https://cloudup.com/cYBMtWClmuz

Testing note: The image settings dialog should catch any changes to the featured image checkbox and prompt you with the dialog. However, since the demo app doesn't handle featured images right now, the change isn't reflected in the editor itself when the screen is closed (so all images are marked as not featured when their settings dialog is opened).

This will require a small change to WPAndroid when milestone `0.5` is merged in (the same one made to `EditorExampleActivity` [here](https://github.com/wordpress-mobile/WordPress-Editor-Android/commit/396ffcdb124e11a9b741d43e6184c37e8781334a#diff-0be19c8bcb324d950b8ac192edc6a0adR65). After this PR is merged, let's keep the #261 issue open to track that (but label it done).

cc @bummytime, @thianhlu, @meremagee
