### PR TITLE
Issue #242: Address lower API CSS issues with uploading image containers

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -24,6 +24,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
+import android.webkit.JavascriptInterface;
 import android.webkit.URLUtil;
 import android.webkit.WebView;
 import android.widget.ToggleButton;
@@ -351,6 +352,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         String htmlEditor = Utils.getHtmlFromFile(getActivity(), "android-editor.html");
 
         mWebView.addJavascriptInterface(new JsCallbackReceiver(this), JS_CALLBACK_HANDLER);
+
+        mWebView.addJavascriptInterface(new NativeStateJsInterface(), "nativeState");
 
         mWebView.loadDataWithBaseURL("file:///android_asset/", htmlEditor, "text/html", "utf-8", "");
 
@@ -1120,6 +1123,14 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             // Insert closing tag
             content.insert(selectionEnd, endTag);
             mSourceViewContent.setSelection(selectionEnd + endTag.length());
+        }
+    }
+
+    private class NativeStateJsInterface {
+
+        @JavascriptInterface
+        public int getAPILevel() {
+            return Build.VERSION.SDK_INT;
         }
     }
 }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -62,6 +62,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     private static final String ARG_PARAM_CONTENT = "param_content";
 
     private static final String JS_CALLBACK_HANDLER = "nativeCallbackHandler";
+    private static final String JS_STATE_INTERFACE = "nativeState";
 
     private static final String KEY_TITLE = "title";
     private static final String KEY_CONTENT = "content";
@@ -379,7 +380,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         }
 
         mWebView.addJavascriptInterface(new JsCallbackReceiver(this), JS_CALLBACK_HANDLER);
-        mWebView.addJavascriptInterface(new NativeStateJsInterface(), "nativeState");
+        mWebView.addJavascriptInterface(new NativeStateJsInterface(), JS_STATE_INTERFACE);
 
         mWebView.loadDataWithBaseURL("file:///android_asset/", htmlEditor, "text/html", "utf-8", "");
 

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1131,7 +1131,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     private void hideActionBarIfNeeded() {
 
         ActionBar actionBar = getActionBar();
-        if (getActionBar() != null
+        if (actionBar != null
                 && !isHardwareKeyboardPresent()
                 && mHideActionBarOnSoftKeyboardUp
                 && mIsKeyboardOpen
@@ -1146,8 +1146,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     private void showActionBarIfNeeded() {
 
         ActionBar actionBar = getActionBar();
-        if (getActionBar() != null && !actionBar.isShowing()) {
-            getActionBar().show();
+        if (actionBar != null && !actionBar.isShowing()) {
+            actionBar.show();
         }
     }
 

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1028,6 +1028,9 @@ ZSSEditor.markImageUploadFailed = function(imageNodeIdentifier, message) {
     if (imageProgressNode.length != 0){
         imageProgressNode.addClass('failed');
     }
+
+    // Delete the compatibility overlay if present
+    imageContainerNode.find("span.upload-overlay").addClass("failed");
 };
 
 /**
@@ -1051,6 +1054,9 @@ ZSSEditor.unmarkImageUploadFailed = function(imageNodeIdentifier, message) {
     if (imageProgressNode.length != 0){
         imageProgressNode.removeClass('failed');
     }
+
+    // Display the compatibility overlay again if present
+    imageContainerNode.find("span.upload-overlay").removeClass("failed");
 };
 
 /**

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -946,6 +946,12 @@ ZSSEditor.setProgressOnImage = function(imageNodeIdentifier, progress) {
         imageNode.addClass("uploading");
     }
 
+    // Revert to non-compatibility image container once image upload has begun. This centers the overlays on the image
+    // (instead of the screen), while still circumventing the small container bug the compat class was added to fix
+    if (progress > 0) {
+        this.getImageContainerNodeWithIdentifier(imageNodeIdentifier).removeClass("compat");
+    }
+
     var imageProgressNode = this.getImageProgressNodeWithIdentifier(imageNodeIdentifier);
     if (imageProgressNode.length == 0){
           return;

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -848,7 +848,7 @@ ZSSEditor.insertLocalImage = function(imageNodeIdentifier, localImageUrl) {
     } else {
         // Before API 19, the WebView didn't support progress tags. Use an upload overlay instead of a progress bar
         var imgContainerClass = 'img_container compat';
-        var progressElement = '<span class="upload-overlay" contenteditable="false">Uploading...</span>';
+        var progressElement = '<span class="upload-overlay" contenteditable="false">Uploading...</span><span class="upload-overlay-bg"></span>';
     }
 
     var imgContainerStart = '<span id="' + imageContainerIdentifier + '" class="' + imgContainerClass + '" contenteditable="false" data-failed="Tap to try again!">';

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -841,11 +841,18 @@ ZSSEditor.insertLocalImage = function(imageNodeIdentifier, localImageUrl) {
     var paragraphCloseTag = '</' + this.defaultParagraphSeparator + '>';
     var progressIdentifier = this.getImageProgressIdentifier(imageNodeIdentifier);
     var imageContainerIdentifier = this.getImageContainerIdentifier(imageNodeIdentifier);
+
+    if (ZSSEditor.androidApiLevel > 18) {
+        var progressElement = '<progress id="' + progressIdentifier + '" value=0 class="wp_media_indicator" contenteditable="false"></progress>';
+    } else {
+        // Before API 19, the WebView didn't support progress tags. Use an upload overlay instead of a progress bar
+        var progressElement = '<span class="upload-overlay" contenteditable="false">Uploading...</span>';
+    }
+
     var imgContainerStart = '<span id="' + imageContainerIdentifier+'" class="img_container" contenteditable="false" data-failed="Tap to try again!">';
     var imgContainerEnd = '</span>';
-    var progress = '<progress id="' + progressIdentifier+'" value=0  class="wp_media_indicator"  contenteditable="false"></progress>';
     var image = '<img data-wpid="' + imageNodeIdentifier + '" src="' + localImageUrl + '" alt="" />';
-    var html = imgContainerStart + progress+image + imgContainerEnd;
+    var html = imgContainerStart + progressElement + image + imgContainerEnd;
 
     if (this.getFocusedField().getHTML().length == 0) {
         html = paragraphOpenTag + html;

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -41,6 +41,9 @@ ZSSEditor.caretInfo = { y: 0, height: 0 };
 // Is this device an iPad
 ZSSEditor.isiPad;
 
+// The API level of the native host (Android)
+ZSSEditor.androidApiLevel;
+
 // The current selection
 ZSSEditor.currentSelection;
 
@@ -68,6 +71,8 @@ ZSSEditor.defaultParagraphSeparator = 'p';
 ZSSEditor.init = function() {
 
     rangy.init();
+
+    ZSSEditor.androidApiLevel = nativeState.getAPILevel();
 
     // Change a few CSS values if the device is an iPad
     ZSSEditor.isiPad = (navigator.userAgent.match(/iPad/i) != null);

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -843,13 +843,15 @@ ZSSEditor.insertLocalImage = function(imageNodeIdentifier, localImageUrl) {
     var imageContainerIdentifier = this.getImageContainerIdentifier(imageNodeIdentifier);
 
     if (ZSSEditor.androidApiLevel > 18) {
+        var imgContainerClass = 'img_container';
         var progressElement = '<progress id="' + progressIdentifier + '" value=0 class="wp_media_indicator" contenteditable="false"></progress>';
     } else {
         // Before API 19, the WebView didn't support progress tags. Use an upload overlay instead of a progress bar
+        var imgContainerClass = 'img_container compat';
         var progressElement = '<span class="upload-overlay" contenteditable="false">Uploading...</span>';
     }
 
-    var imgContainerStart = '<span id="' + imageContainerIdentifier+'" class="img_container" contenteditable="false" data-failed="Tap to try again!">';
+    var imgContainerStart = '<span id="' + imageContainerIdentifier + '" class="' + imgContainerClass + '" contenteditable="false" data-failed="Tap to try again!">';
     var imgContainerEnd = '</span>';
     var image = '<img data-wpid="' + imageNodeIdentifier + '" src="' + localImageUrl + '" alt="" />';
     var html = imgContainerStart + progressElement + image + imgContainerEnd;

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -2361,6 +2361,15 @@ ZSSField.prototype.handleTapEvent = function(e) {
             return;
         }
 
+        if (targetNode.className.indexOf('upload-overlay') != -1 ||
+            targetNode.className.indexOf('upload-overlay-bg') != -1 ) {
+            // Select the image node associated with the selected upload overlay
+            var imageNode = targetNode.parentNode.getElementsByTagName('img')[0];
+
+            this.sendImageTappedCallback( imageNode );
+            return;
+        }
+
         if ( ZSSEditor.currentEditingImage ) {
             ZSSEditor.removeImageSelectionFormatting( ZSSEditor.currentEditingImage );
             ZSSEditor.currentEditingImage = null;

--- a/libs/editor-common/assets/editor-android.css
+++ b/libs/editor-common/assets/editor-android.css
@@ -22,3 +22,20 @@
     display: block;
     background-color: rgba(0, 0, 0, 0.5);
 }
+
+/* Used only on older APIs (API<19) instead of a progress bar for uploading images, since the WebView at those API
+   levels does not support the progress tag */
+.img_container .upload-overlay {
+    position: absolute;
+    top: 50%;
+    -webkit-transform: translateY(-50%);
+    width:100%;
+    z-index: 100;
+    min-width: 60px;
+    font-family:OpenSans;
+    font-size:20px;
+    font-weight:600;
+    text-align: center;
+    text-shadow: 0px 1px 2px rgba(0,0,0,.06);
+    color: white;
+}

--- a/libs/editor-common/assets/editor-android.css
+++ b/libs/editor-common/assets/editor-android.css
@@ -44,3 +44,7 @@ span.img_container.compat {
     text-shadow: 0px 1px 2px rgba(0,0,0,.06);
     color: white;
 }
+
+.img_container .upload-overlay.failed {
+    visibility: hidden;
+}

--- a/libs/editor-common/assets/editor-android.css
+++ b/libs/editor-common/assets/editor-android.css
@@ -40,6 +40,20 @@ light */
     background-color: rgba(0, 0, 0, 0.5);
 }
 
+/* When the upload-overlay-bg element is present (API<19), a bug is exposed where the img_container is slightly larger
+than its containing image. The upload-overlay-bg is larger as well, leaving a dark line below the image. By setting
+display:block on the image and setting a width limit we get around this issue. */
+
+.img_container .upload-overlay-bg ~ img.uploading {
+    display:block;
+    max-width:100%;
+}
+
+.img_container .upload-overlay-bg ~ img.failed {
+    display:block;
+    max-width:100%;
+}
+
 /* Used only on older APIs (API<19) instead of a progress bar for uploading images, since the WebView at those API
    levels does not support the progress tag */
 .img_container .upload-overlay {

--- a/libs/editor-common/assets/editor-android.css
+++ b/libs/editor-common/assets/editor-android.css
@@ -12,6 +12,8 @@
     }
 }
 
+/* --- API<19 workarounds --- */
+
 /* Used only on older APIs (API<19), which don't support CSS filter effects (specifically, blur). */
 .edit-container .edit-overlay-bg {
     position: absolute;
@@ -26,6 +28,16 @@
 /* Used only on older APIs (API<19), where using inline-block is buggy and sometimes displays a very small container */
 span.img_container.compat {
     display: block;
+}
+
+/* Used on API<19 to darken the image so that the 'uploading' and 'retry' overlays can still be seen when the image is
+light */
+.img_container .upload-overlay-bg {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    display: block;
+    background-color: rgba(0, 0, 0, 0.5);
 }
 
 /* Used only on older APIs (API<19) instead of a progress bar for uploading images, since the WebView at those API

--- a/libs/editor-common/assets/editor-android.css
+++ b/libs/editor-common/assets/editor-android.css
@@ -23,6 +23,11 @@
     background-color: rgba(0, 0, 0, 0.5);
 }
 
+/* Used only on older APIs (API<19), where using inline-block is buggy and sometimes displays a very small container */
+span.img_container.compat {
+    display: block;
+}
+
 /* Used only on older APIs (API<19) instead of a progress bar for uploading images, since the WebView at those API
    levels does not support the progress tag */
 .img_container .upload-overlay {


### PR DESCRIPTION
Fixes #242, addressing the following bugs that appear on `API < 19` only:
- Fixes the issue where the uploading image container would sometimes be very small: https://cloudup.com/c2HhsInzXsW
- Because the `API < 19` `WebView` doesn't support the progress tag, there is no indication that the image is uploading. For those API levels, an 'Uploading...' overlay is shown instead:

![242-upload-overlay-text-old-api](https://cloud.githubusercontent.com/assets/9613966/10137628/c15c06e4-65fa-11e5-9bbd-4f4b6e0c9ed1.png)

Some explanation about 9e1863f: Fixing the initial issue with the small containers required using `display: block` instead of `display: inline-block`. But this makes the container fill the screen width rather than match the image size, so for images less wide than the screen the overlays are skewed:

![242-uploading-image-block-bug-api18](https://cloud.githubusercontent.com/assets/9613966/11458278/e2a296f4-968a-11e5-855a-4fab76db6d99.png)

I found that once the image has loaded (on progress updates after the initial one which merely initializes the progress bar), we can safely drop back to `inline-block` on those API levels. This keeps the small container fix working, but also properly centers the overlays on the image for smaller images:

![242-uploading-image-inline-block-api18](https://cloud.githubusercontent.com/assets/9613966/11458291/0e41b236-968b-11e5-9387-dbaa15b296a5.png)

It's not an ideal fix as we may occasionally see a brief alignment issue until the first progress update comes in, but I haven't found a better way to fix both things at once so far.

cc @bummytime @thianhlu
