### PR TITLE
Fix #15 track visual editor events

### DIFF
--- a/WordPressEditor/build.gradle
+++ b/WordPressEditor/build.gradle
@@ -48,7 +48,7 @@ android {
 dependencies {
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.android.support:support-v4:23.1.1'
-    compile 'org.wordpress:analytics:1.0.0'
+    compile 'org.wordpress:analytics:1.1.0'
     compile 'org.wordpress:utils:1.6.0'
 
     // Test libraries

--- a/WordPressEditor/build.gradle
+++ b/WordPressEditor/build.gradle
@@ -48,7 +48,7 @@ android {
 dependencies {
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.android.support:support-v4:23.1.1'
-    compile 'org.wordpress:analytics:1.1.0'
+    compile 'org.wordpress:analytics:1.2.0'
     compile 'org.wordpress:utils:1.6.0'
 
     // Test libraries

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -800,7 +800,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         mWebView.post(new Runnable() {
             @Override
             public void run() {
-                AnalyticsTracker.track(Stat.EDITOR_UPDLOAD_MEDIA_FAILED);
+                AnalyticsTracker.track(Stat.EDITOR_UPLOAD_MEDIA_FAILED);
                 mWebView.execJavaScriptFromString("ZSSEditor.markImageUploadFailed(" + mediaId + ");");
                 mFailedMediaIds.add(mediaId);
                 mUploadingMediaIds.remove(mediaId);
@@ -959,7 +959,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 mWebView.post(new Runnable() {
                     @Override
                     public void run() {
-                        AnalyticsTracker.track(Stat.EDITOR_UPDLOAD_MEDIA_RETRIED);
+                        AnalyticsTracker.track(Stat.EDITOR_UPLOAD_MEDIA_RETRIED);
                         mWebView.execJavaScriptFromString("ZSSEditor.unmarkImageUploadFailed(" + mediaId + ");");
                         mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + mediaId + ", " + 0 + ");");
                         mFailedMediaIds.remove(mediaId);

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -974,7 +974,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 if (fragmentManager.findFragmentByTag(ImageSettingsDialogFragment.IMAGE_SETTINGS_DIALOG_TAG) != null) {
                     return;
                 }
-
+                AnalyticsTracker.track(Stat.EDITOR_EDITED_IMAGE);
                 ImageSettingsDialogFragment imageSettingsDialogFragment = new ImageSettingsDialogFragment();
                 imageSettingsDialogFragment.setTargetFragment(this,
                         ImageSettingsDialogFragment.IMAGE_SETTINGS_DIALOG_REQUEST_CODE);

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -31,6 +31,8 @@ import android.widget.ToggleButton;
 import com.android.volley.toolbox.ImageLoader;
 
 import org.json.JSONObject;
+import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.JSONUtils;
@@ -369,6 +371,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     public void onClick(View v) {
         int id = v.getId();
         if (id == R.id.format_bar_button_html) {
+            AnalyticsTracker.track(Stat.EDITOR_TAPPED_HTML);
+
             // Don't switch to HTML mode if currently uploading media
             if (!mUploadingMediaIds.isEmpty()) {
                 ((ToggleButton) v).setChecked(false);
@@ -409,6 +413,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_content').focus();");
             }
         } else if (id == R.id.format_bar_button_media) {
+            AnalyticsTracker.track(Stat.EDITOR_TAPPED_IMAGE);
             ((ToggleButton) v).setChecked(false);
 
             if (mSourceView.getVisibility() == View.VISIBLE) {
@@ -423,8 +428,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             if (!((ToggleButton) v).isChecked()) {
                 // The link button was checked when it was pressed; remove the current link
                 mWebView.execJavaScriptFromString("ZSSEditor.unlink();");
+                AnalyticsTracker.track(Stat.EDITOR_TAPPED_UNLINK);
                 return;
             }
+            AnalyticsTracker.track(Stat.EDITOR_TAPPED_LINK);
 
             ((ToggleButton) v).setChecked(false);
 
@@ -710,11 +717,13 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 if (URLUtil.isNetworkUrl(mediaUrl)) {
                     String mediaId = mediaFile.getMediaId();
                     mWebView.execJavaScriptFromString("ZSSEditor.insertImage('" + mediaUrl + "', '" + mediaId + "');");
+                    AnalyticsTracker.track(Stat.EDITOR_ADDED_PHOTO_VIA_WP_MEDIA_LIBRARY);
                 } else {
                     String id = mediaFile.getMediaId();
                     mWebView.execJavaScriptFromString("ZSSEditor.insertLocalImage(" + id + ", '" + mediaUrl + "');");
                     mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + id + ", " + 0 + ");");
                     mUploadingMediaIds.add(id);
+                    AnalyticsTracker.track(Stat.EDITOR_ADDED_PHOTO_VIA_LOCAL_LIBRARY);
                 }
             }
         });
@@ -791,6 +800,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         mWebView.post(new Runnable() {
             @Override
             public void run() {
+                AnalyticsTracker.track(Stat.EDITOR_UPDLOAD_MEDIA_FAILED);
                 mWebView.execJavaScriptFromString("ZSSEditor.markImageUploadFailed(" + mediaId + ");");
                 mFailedMediaIds.add(mediaId);
                 mUploadingMediaIds.remove(mediaId);
@@ -949,6 +959,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 mWebView.post(new Runnable() {
                     @Override
                     public void run() {
+                        AnalyticsTracker.track(Stat.EDITOR_UPDLOAD_MEDIA_RETRIED);
                         mWebView.execJavaScriptFromString("ZSSEditor.unmarkImageUploadFailed(" + mediaId + ");");
                         mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + mediaId + ", " + 0 + ");");
                         mFailedMediaIds.remove(mediaId);
@@ -1106,11 +1117,28 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
     private void onFormattingButtonClicked(ToggleButton toggleButton) {
         String tag = toggleButton.getTag().toString();
-
+        trackFormattingButtonClicked(toggleButton);
         if (mWebView.getVisibility() == View.VISIBLE) {
             mWebView.execJavaScriptFromString("ZSSEditor.set" + StringUtils.capitalize(tag) + "();");
         } else {
             applyFormattingHtmlMode(toggleButton, tag);
+        }
+    }
+
+    private void trackFormattingButtonClicked(ToggleButton toggleButton) {
+        int id = toggleButton.getId();
+        if (id == R.id.format_bar_button_bold) {
+            AnalyticsTracker.track(Stat.EDITOR_TAPPED_BOLD);
+        } else if (id == R.id.format_bar_button_italic) {
+            AnalyticsTracker.track(Stat.EDITOR_TAPPED_ITALIC);
+        } else if (id == R.id.format_bar_button_ol) {
+            AnalyticsTracker.track(Stat.EDITOR_TAPPED_ORDERED_LIST);
+        } else if (id == R.id.format_bar_button_ul) {
+            AnalyticsTracker.track(Stat.EDITOR_TAPPED_UNORDERED_LIST);
+        } else if (id == R.id.format_bar_button_quote) {
+            AnalyticsTracker.track(Stat.EDITOR_TAPPED_BLOCKQUOTE);
+        } else if (id == R.id.format_bar_button_strikethrough) {
+            AnalyticsTracker.track(Stat.EDITOR_TAPPED_STRIKETHROUGH);
         }
     }
 


### PR DESCRIPTION
Fix #15 track visual editor events
- Done in this PR
  EDITOR_ADDED_PHOTO_VIA_LOCAL_LIBRARY,
  EDITOR_ADDED_PHOTO_VIA_WP_MEDIA_LIBRARY,
  EDITOR_TAPPED_HTML,
  EDITOR_TAPPED_IMAGE,
  EDITOR_TAPPED_LINK,
  EDITOR_TAPPED_UNLINK,
  EDITOR_TAPPED_BOLD,
  EDITOR_TAPPED_ITALIC,
  EDITOR_TAPPED_ORDERED_LIST,
  EDITOR_TAPPED_UNORDERED_LIST,
  EDITOR_TAPPED_BLOCKQUOTE,
  EDITOR_TAPPED_STRIKETHROUGH,
  EDITOR_UPLOAD_MEDIA_FAILED
  EDITOR_UPLOAD_MEDIA_RETRIED
  EDITOR_EDITED_IMAGE,
- Done in wpandroid
  EDITOR_CLOSED,
  EDITOR_CREATED_POST,
  EDITOR_PUBLISHED_POST,
  EDITOR_SAVED_DRAFT,
  EDITOR_SCHEDULED_POST,
  EDITOR_UPDATED_POST,
- To do in wpandroid https://github.com/wordpress-mobile/WordPress-Android/issues/3582
  EDITOR_DISCARDED_CHANGES,
  EDITOR_ENABLED_NEW_VERSION,
  EDITOR_TOGGLED_OFF,
  EDITOR_TOGGLED_ON,
- To do in #121
  EDITOR_ADDED_VIDEO_VIA_LOCAL_LIBRARY,
  EDITOR_ADDED_VIDEO_VIA_WP_MEDIA_LIBRARY,
- Doesn't exist in the visual editor
  EDITOR_TAPPED_MORE,
  EDITOR_TAPPED_UNDERLINE,
