### PR TITLE
Fix #183: Visual and Legacy editors accessibility

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -360,16 +360,16 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     }
 
     protected void initJsEditor() {
-        if(!isAdded()) {
+        if (!isAdded()) {
             return;
         }
 
         String htmlEditor = Utils.getHtmlFromFile(getActivity(), "android-editor.html");
-
+        if (htmlEditor != null) {
+            htmlEditor = htmlEditor.replace("%%TITLE%%", getString(R.string.visual_editor));
+        }
         mWebView.addJavascriptInterface(new JsCallbackReceiver(this), JS_CALLBACK_HANDLER);
-
         mWebView.loadDataWithBaseURL("file:///android_asset/", htmlEditor, "text/html", "utf-8", "");
-
         if (mDebugModeEnabled) {
             enableWebDebugging(true);
             // Enable the HTML logging button

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/RippleToggleButton.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/RippleToggleButton.java
@@ -21,12 +21,11 @@ public class RippleToggleButton extends ToggleButton {
     private Paint mStrokePaint;
 
     public RippleToggleButton(Context context) {
-        super(context);
-    }
+        this(context, null);
+   }
 
     public RippleToggleButton(Context context, AttributeSet attrs) {
-        super(context, attrs);
-        init();
+        this(context, attrs, 0);
     }
 
     public RippleToggleButton(Context context, AttributeSet attrs, int defStyle) {

--- a/WordPressEditor/src/main/res/layout-w360dp/format_bar.xml
+++ b/WordPressEditor/src/main/res/layout-w360dp/format_bar.xml
@@ -37,6 +37,7 @@
                 style="@style/FormatBarButton"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
+                android:contentDescription="@string/format_bar_description_media"
                 android:background="@drawable/format_bar_button_media_selector"/>
 
             <org.wordpress.android.editor.RippleToggleButton
@@ -44,6 +45,7 @@
                 style="@style/FormatBarButton"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
+                android:contentDescription="@string/format_bar_description_bold"
                 android:background="@drawable/format_bar_button_bold_selector"
                 android:tag="@string/format_bar_tag_bold"/>
 
@@ -52,6 +54,7 @@
                 style="@style/FormatBarButton"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
+                android:contentDescription="@string/format_bar_description_italic"
                 android:background="@drawable/format_bar_button_italic_selector"
                 android:tag="@string/format_bar_tag_italic"/>
 
@@ -60,6 +63,7 @@
                 style="@style/FormatBarButton"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
+                android:contentDescription="@string/format_bar_description_quote"
                 android:background="@drawable/format_bar_button_quote_selector"
                 android:tag="@string/format_bar_tag_blockquote"/>
 
@@ -68,6 +72,7 @@
                 style="@style/FormatBarButton"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
+                android:contentDescription="@string/format_bar_description_ul"
                 android:background="@drawable/format_bar_button_ul_selector"
                 android:tag="@string/format_bar_tag_unorderedList"/>
 
@@ -76,6 +81,7 @@
                 style="@style/FormatBarButton"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
+                android:contentDescription="@string/format_bar_description_ol"
                 android:background="@drawable/format_bar_button_ol_selector"
                 android:tag="@string/format_bar_tag_orderedList"/>
 
@@ -84,6 +90,7 @@
                 style="@style/FormatBarButton"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
+                android:contentDescription="@string/format_bar_description_link"
                 android:background="@drawable/format_bar_button_link_selector"
                 android:tag="@string/format_bar_tag_link"/>
         </LinearLayout>
@@ -100,6 +107,7 @@
             style="@style/FormatBarHtmlButton"
             android:layout_width="wrap_content"
             android:layout_height="fill_parent"
+            android:contentDescription="@string/format_bar_description_html"
             android:background="@drawable/format_bar_button_html_selector"/>
     </LinearLayout>
 </LinearLayout>

--- a/WordPressEditor/src/main/res/layout-w380dp/format_bar.xml
+++ b/WordPressEditor/src/main/res/layout-w380dp/format_bar.xml
@@ -31,6 +31,7 @@
             android:layout_width="wrap_content"
             android:layout_height="fill_parent"
             android:layout_weight="1"
+            android:contentDescription="@string/format_bar_description_media"
             android:background="@drawable/format_bar_button_media_selector"/>
 
         <org.wordpress.android.editor.RippleToggleButton
@@ -39,6 +40,7 @@
             android:layout_width="wrap_content"
             android:layout_height="fill_parent"
             android:layout_weight="1"
+            android:contentDescription="@string/format_bar_description_bold"
             android:background="@drawable/format_bar_button_bold_selector"
             android:tag="@string/format_bar_tag_bold"/>
 
@@ -48,6 +50,7 @@
             android:layout_width="wrap_content"
             android:layout_height="fill_parent"
             android:layout_weight="1"
+            android:contentDescription="@string/format_bar_description_italic"
             android:background="@drawable/format_bar_button_italic_selector"
             android:tag="@string/format_bar_tag_italic"/>
 
@@ -57,6 +60,7 @@
             android:layout_width="wrap_content"
             android:layout_height="fill_parent"
             android:layout_weight="1"
+            android:contentDescription="@string/format_bar_description_quote"
             android:background="@drawable/format_bar_button_quote_selector"
             android:tag="@string/format_bar_tag_blockquote"/>
 
@@ -66,6 +70,7 @@
             android:layout_width="wrap_content"
             android:layout_height="fill_parent"
             android:layout_weight="1"
+            android:contentDescription="@string/format_bar_description_ul"
             android:background="@drawable/format_bar_button_ul_selector"
             android:tag="@string/format_bar_tag_unorderedList"/>
 
@@ -75,6 +80,7 @@
             android:layout_width="wrap_content"
             android:layout_height="fill_parent"
             android:layout_weight="1"
+            android:contentDescription="@string/format_bar_description_ol"
             android:background="@drawable/format_bar_button_ol_selector"
             android:tag="@string/format_bar_tag_orderedList"/>
 
@@ -84,6 +90,7 @@
             android:layout_width="wrap_content"
             android:layout_height="fill_parent"
             android:layout_weight="1"
+            android:contentDescription="@string/format_bar_description_link"
             android:background="@drawable/format_bar_button_link_selector"
             android:tag="@string/format_bar_tag_link"/>
 
@@ -99,6 +106,7 @@
             style="@style/FormatBarHtmlButton"
             android:layout_width="wrap_content"
             android:layout_height="fill_parent"
+            android:contentDescription="@string/format_bar_description_html"
             android:background="@drawable/format_bar_button_html_selector"/>
     </LinearLayout>
 </LinearLayout>

--- a/WordPressEditor/src/main/res/layout-w600dp/format_bar.xml
+++ b/WordPressEditor/src/main/res/layout-w600dp/format_bar.xml
@@ -34,6 +34,7 @@
                 style="@style/FormatBarButtonTablet"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
+                android:contentDescription="@string/format_bar_description_media"
                 android:background="@drawable/format_bar_button_media_selector"/>
         </LinearLayout>
 
@@ -47,6 +48,7 @@
                 style="@style/FormatBarButtonTablet"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
+                android:contentDescription="@string/format_bar_description_bold"
                 android:background="@drawable/format_bar_button_bold_selector"
                 android:tag="@string/format_bar_tag_bold"/>
 
@@ -55,6 +57,7 @@
                 style="@style/FormatBarButtonTablet"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
+                android:contentDescription="@string/format_bar_description_italic"
                 android:background="@drawable/format_bar_button_italic_selector"
                 android:tag="@string/format_bar_tag_italic"/>
 
@@ -77,6 +80,7 @@
                 style="@style/FormatBarButtonTablet"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
+                android:contentDescription="@string/format_bar_description_link"
                 android:background="@drawable/format_bar_button_link_selector"
                 android:tag="@string/format_bar_tag_link"/>
         </LinearLayout>
@@ -91,6 +95,7 @@
                 style="@style/FormatBarButtonTablet"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
+                android:contentDescription="@string/format_bar_description_ul"
                 android:background="@drawable/format_bar_button_ul_selector"
                 android:tag="@string/format_bar_tag_unorderedList"/>
 
@@ -99,6 +104,7 @@
                 style="@style/FormatBarButtonTablet"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
+                android:contentDescription="@string/format_bar_description_ol"
                 android:background="@drawable/format_bar_button_ol_selector"
                 android:tag="@string/format_bar_tag_orderedList"/>
 
@@ -107,6 +113,7 @@
                 style="@style/FormatBarButtonTablet"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
+                android:contentDescription="@string/format_bar_description_quote"
                 android:background="@drawable/format_bar_button_quote_selector"
                 android:tag="@string/format_bar_tag_blockquote"/>
         </LinearLayout>
@@ -121,6 +128,7 @@
                 style="@style/FormatBarButtonTablet"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
+                android:contentDescription="@string/format_bar_description_html"
                 android:background="@drawable/format_bar_button_html_selector"/>
         </LinearLayout>
     </LinearLayout>

--- a/WordPressEditor/src/main/res/layout/dialog_image_options.xml
+++ b/WordPressEditor/src/main/res/layout/dialog_image_options.xml
@@ -21,6 +21,7 @@
 
             <ImageView
                 android:id="@+id/image_thumbnail"
+                android:contentDescription="@string/image_thumbnail"
                 android:layout_width="@dimen/image_settings_dialog_thumbnail_size"
                 android:layout_height="@dimen/image_settings_dialog_thumbnail_size"
                 android:layout_marginLeft="@dimen/image_settings_dialog_thumbnail_left_margin"

--- a/WordPressEditor/src/main/res/layout/format_bar.xml
+++ b/WordPressEditor/src/main/res/layout/format_bar.xml
@@ -42,6 +42,7 @@
                     style="@style/FormatBarButton"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
+                    android:contentDescription="@string/format_bar_description_media"
                     android:background="@drawable/format_bar_button_media_selector"/>
 
                 <org.wordpress.android.editor.RippleToggleButton
@@ -49,6 +50,7 @@
                     style="@style/FormatBarButton"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
+                    android:contentDescription="@string/format_bar_description_bold"
                     android:background="@drawable/format_bar_button_bold_selector"
                     android:tag="@string/format_bar_tag_bold"/>
 
@@ -57,6 +59,7 @@
                     style="@style/FormatBarButton"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
+                    android:contentDescription="@string/format_bar_description_italic"
                     android:background="@drawable/format_bar_button_italic_selector"
                     android:tag="@string/format_bar_tag_italic"/>
 
@@ -65,6 +68,7 @@
                     style="@style/FormatBarButton"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
+                    android:contentDescription="@string/format_bar_description_quote"
                     android:background="@drawable/format_bar_button_quote_selector"
                     android:tag="@string/format_bar_tag_blockquote"/>
 
@@ -73,6 +77,7 @@
                     style="@style/FormatBarButton"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
+                    android:contentDescription="@string/format_bar_description_ul"
                     android:background="@drawable/format_bar_button_ul_selector"
                     android:tag="@string/format_bar_tag_unorderedList"/>
 
@@ -81,6 +86,7 @@
                     style="@style/FormatBarButton"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
+                    android:contentDescription="@string/format_bar_description_ol"
                     android:background="@drawable/format_bar_button_ol_selector"
                     android:tag="@string/format_bar_tag_orderedList"/>
 
@@ -89,6 +95,7 @@
                     style="@style/FormatBarButton"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
+                    android:contentDescription="@string/format_bar_description_link"
                     android:background="@drawable/format_bar_button_link_selector"
                     android:tag="@string/format_bar_tag_link"/>
             </LinearLayout>
@@ -106,6 +113,7 @@
             style="@style/FormatBarHtmlButton"
             android:layout_width="wrap_content"
             android:layout_height="fill_parent"
+            android:contentDescription="@string/format_bar_description_html"
             android:background="@drawable/format_bar_button_html_selector"/>
     </LinearLayout>
 </LinearLayout>

--- a/WordPressEditor/src/main/res/layout/fragment_edit_post_content.xml
+++ b/WordPressEditor/src/main/res/layout/fragment_edit_post_content.xml
@@ -100,6 +100,7 @@
                     style="@style/LegacyToggleButton"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
+                    android:contentDescription="@string/format_bar_description_bold"
                     android:background="@drawable/legacy_format_bar_button_bold_selector" />
 
                 <ToggleButton
@@ -107,6 +108,7 @@
                     style="@style/LegacyToggleButton"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
+                    android:contentDescription="@string/format_bar_description_italic"
                     android:background="@drawable/legacy_format_bar_button_italic_selector" />
 
                 <ToggleButton
@@ -114,6 +116,7 @@
                     style="@style/LegacyToggleButton"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
+                    android:contentDescription="@string/format_bar_description_underline"
                     android:background="@drawable/legacy_format_bar_button_underline_selector" />
 
                 <ToggleButton
@@ -121,6 +124,7 @@
                     style="@style/LegacyToggleButton"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
+                    android:contentDescription="@string/format_bar_description_strike"
                     android:background="@drawable/legacy_format_bar_button_strike_selector" />
 
                 <ToggleButton
@@ -128,6 +132,7 @@
                     style="@style/LegacyToggleButton"
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
+                    android:contentDescription="@string/format_bar_description_quote"
                     android:background="@drawable/legacy_format_bar_button_quote_selector" />
 
                 <Button
@@ -135,6 +140,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
                     android:minWidth="@dimen/legacy_format_bar_height"
+                    android:contentDescription="@string/format_bar_description_link"
                     android:background="@drawable/legacy_format_bar_button_link_selector" />
 
                 <Button
@@ -142,6 +148,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="fill_parent"
                     android:minWidth="@dimen/legacy_format_bar_height"
+                    android:contentDescription="@string/format_bar_description_more"
                     android:background="@drawable/legacy_format_bar_button_more_selector" />
             </LinearLayout>
         </HorizontalScrollView>
@@ -151,6 +158,7 @@
             android:layout_width="wrap_content"
             android:layout_height="fill_parent"
             android:minWidth="@dimen/legacy_format_bar_height"
+            android:contentDescription="@string/format_bar_description_media"
             android:background="@drawable/legacy_format_bar_button_media_selector" />
     </LinearLayout>
 

--- a/WordPressEditor/src/main/res/values/strings.xml
+++ b/WordPressEditor/src/main/res/values/strings.xml
@@ -65,7 +65,7 @@
     <string name="format_bar_description_bold">Bold</string>
     <string name="format_bar_description_italic">Italic</string>
     <string name="format_bar_description_underline">Underline</string>
-    <string name="format_bar_description_strike">Strike</string>
+    <string name="format_bar_description_strike">Strikethrough</string>
     <string name="format_bar_description_quote">Block quote</string>
     <string name="format_bar_description_link">Insert link</string>
     <string name="format_bar_description_more">Insert more</string>

--- a/WordPressEditor/src/main/res/values/strings.xml
+++ b/WordPressEditor/src/main/res/values/strings.xml
@@ -74,5 +74,6 @@
     <string name="format_bar_description_ol">Ordered list</string>
     <string name="format_bar_description_html">HTML mode</string>
     <string name="visual_editor">Visual editor</string>
+    <string name="image_thumbnail">Image thumbnail</string>
 
 </resources>

--- a/WordPressEditor/src/main/res/values/strings.xml
+++ b/WordPressEditor/src/main/res/values/strings.xml
@@ -73,4 +73,6 @@
     <string name="format_bar_description_ul">Unordered list</string>
     <string name="format_bar_description_ol">Ordered list</string>
     <string name="format_bar_description_html">HTML mode</string>
+    <string name="visual_editor">Visual editor</string>
+
 </resources>

--- a/WordPressEditor/src/main/res/values/strings.xml
+++ b/WordPressEditor/src/main/res/values/strings.xml
@@ -61,4 +61,16 @@
         <item>Full Size</item>
     </string-array>
 
+    <!-- Accessibility - format bar button descriptions -->
+    <string name="format_bar_description_bold">Bold</string>
+    <string name="format_bar_description_italic">Italic</string>
+    <string name="format_bar_description_underline">Underline</string>
+    <string name="format_bar_description_strike">Strike</string>
+    <string name="format_bar_description_quote">Block quote</string>
+    <string name="format_bar_description_link">Insert link</string>
+    <string name="format_bar_description_more">Insert more</string>
+    <string name="format_bar_description_media">Insert media</string>
+    <string name="format_bar_description_ul">Unordered list</string>
+    <string name="format_bar_description_ol">Ordered list</string>
+    <string name="format_bar_description_html">HTML mode</string>
 </resources>

--- a/libs/editor-common/assets/android-editor.html
+++ b/libs/editor-common/assets/android-editor.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>ZSSRichTextEditor</title>
+    <title>Visual Editor</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=0">
     <script src="jquery-2.1.3.min.js"></script>
     <script src="js-beautifier.js"></script>

--- a/libs/editor-common/assets/android-editor.html
+++ b/libs/editor-common/assets/android-editor.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Visual Editor</title>
+    <title>%%TITLE%%</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=0">
     <script src="jquery-2.1.3.min.js"></script>
     <script src="js-beautifier.js"></script>


### PR DESCRIPTION
Fix #183: Visual and Legacy editors accessibility
- [x] Label the format bar buttons
- [x] Change the title of the HTML file to something more appropriate ("Visual Editor" perhaps)
- [x] The post and image settings screens both need accessibility labels for the various fields (small changes here, image settings was pretty easy to use with Talkback)
- [x] <s> Related to the above, we should make the switch between visual/HTML mode more obvious. Maybe a toast ("Switched to visual mode", "Switched to HTML mode"), those seem to be read out automatically (this also came up in the iOS editor issue above).</s>  (Not implemented)

I've tried to avoid `%%TITLE%%` text replacement, but none actually worked:
- `mWebView.execJavaScriptFromString("document.title = 'Test';");`
- `mWebView.setContentDescription("Test");` 
  (same results with or without the `<title>` in the html file)

Alternative solution is to remove the title completely, not sure this is a problem for our users.

Related https://github.com/wordpress-mobile/WordPress-Android/pull/3666
