### PR TITLE
Issue #24: addJavascriptInterface security fix

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -377,7 +377,15 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             htmlEditor = htmlEditor.replace("%%TITLE%%", getString(R.string.visual_editor));
         }
 
-        mWebView.addJavascriptInterface(new JsCallbackReceiver(this), JS_CALLBACK_HANDLER);
+        // To avoid reflection security issues with JavascriptInterface on API<17, we use an iframe to make URL requests
+        // for callbacks from JS instead. These are received by WebViewClient.shouldOverrideUrlLoading() and then
+        // passed on to the JsCallbackReceiver
+        if (Build.VERSION.SDK_INT < 17) {
+            mWebView.setJsCallbackReceiver(new JsCallbackReceiver(this));
+        } else {
+            mWebView.addJavascriptInterface(new JsCallbackReceiver(this), JS_CALLBACK_HANDLER);
+        }
+
         mWebView.addJavascriptInterface(new NativeStateJsInterface(getActivity().getApplicationContext()),
                                         JS_STATE_INTERFACE);
 

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -375,6 +375,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         String htmlEditor = Utils.getHtmlFromFile(getActivity(), "android-editor.html");
         if (htmlEditor != null) {
             htmlEditor = htmlEditor.replace("%%TITLE%%", getString(R.string.visual_editor));
+            htmlEditor = htmlEditor.replace("%%ANDROID_API_LEVEL%%", String.valueOf(Build.VERSION.SDK_INT));
         }
 
         // To avoid reflection security issues with JavascriptInterface on API<17, we use an iframe to make URL requests
@@ -1295,11 +1296,6 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         @JavascriptInterface
         public String getStringUploadingGallery() {
             return mContext.getString(R.string.uploading_gallery_placeholder);
-        }
-
-        @JavascriptInterface
-        public int getAPILevel() {
-            return Build.VERSION.SDK_INT;
         }
     }
 }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -60,7 +60,6 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     private static final String ARG_PARAM_CONTENT = "param_content";
 
     private static final String JS_CALLBACK_HANDLER = "nativeCallbackHandler";
-    private static final String JS_STATE_INTERFACE = "nativeState";
 
     private static final String KEY_TITLE = "title";
     private static final String KEY_CONTENT = "content";
@@ -376,6 +375,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         if (htmlEditor != null) {
             htmlEditor = htmlEditor.replace("%%TITLE%%", getString(R.string.visual_editor));
             htmlEditor = htmlEditor.replace("%%ANDROID_API_LEVEL%%", String.valueOf(Build.VERSION.SDK_INT));
+            htmlEditor = htmlEditor.replace("%%LOCALIZED_STRING_INIT%%",
+                    "nativeState.localizedStringEdit = '" + getString(R.string.edit) + "';\n" +
+                    "nativeState.localizedStringUploading = '" + getString(R.string.uploading) + "';\n" +
+                    "nativeState.localizedStringUploadingGallery = '" + getString(R.string.uploading_gallery_placeholder) + "';\n");
         }
 
         // To avoid reflection security issues with JavascriptInterface on API<17, we use an iframe to make URL requests
@@ -386,9 +389,6 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         } else {
             mWebView.addJavascriptInterface(new JsCallbackReceiver(this), JS_CALLBACK_HANDLER);
         }
-
-        mWebView.addJavascriptInterface(new NativeStateJsInterface(getActivity().getApplicationContext()),
-                                        JS_STATE_INTERFACE);
 
         mWebView.loadDataWithBaseURL("file:///android_asset/", htmlEditor, "text/html", "utf-8", "");
 
@@ -1273,29 +1273,6 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             // Insert closing tag
             content.insert(selectionEnd, endTag);
             mSourceViewContent.setSelection(selectionEnd + endTag.length());
-        }
-    }
-
-    private class NativeStateJsInterface {
-        Context mContext;
-
-        NativeStateJsInterface(Context context) {
-            mContext = context;
-        }
-
-        @JavascriptInterface
-        public String getStringEdit() {
-            return mContext.getString(R.string.edit);
-        }
-
-        @JavascriptInterface
-        public String getStringUploading() {
-            return mContext.getString(R.string.uploading);
-        }
-
-        @JavascriptInterface
-        public String getStringUploadingGallery() {
-            return mContext.getString(R.string.uploading_gallery_placeholder);
         }
     }
 }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -24,7 +24,6 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
-import android.webkit.JavascriptInterface;
 import android.webkit.URLUtil;
 import android.webkit.WebView;
 import android.widget.ToggleButton;
@@ -60,7 +59,6 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     private static final String ARG_PARAM_CONTENT = "param_content";
 
     private static final String JS_CALLBACK_HANDLER = "nativeCallbackHandler";
-    private static final String JS_STATE_INTERFACE = "nativeState";
 
     private static final String KEY_TITLE = "title";
     private static final String KEY_CONTENT = "content";
@@ -376,6 +374,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         if (htmlEditor != null) {
             htmlEditor = htmlEditor.replace("%%TITLE%%", getString(R.string.visual_editor));
             htmlEditor = htmlEditor.replace("%%ANDROID_API_LEVEL%%", String.valueOf(Build.VERSION.SDK_INT));
+            htmlEditor = htmlEditor.replace("%%LOCALIZED_STRING_INIT%%",
+                    "nativeState.localizedStringEdit = '" + getString(R.string.edit) + "';\n" +
+                    "nativeState.localizedStringUploading = '" + getString(R.string.uploading) + "';\n" +
+                    "nativeState.localizedStringUploadingGallery = '" + getString(R.string.uploading_gallery_placeholder) + "';\n");
         }
 
         // To avoid reflection security issues with JavascriptInterface on API<17, we use an iframe to make URL requests
@@ -386,9 +388,6 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         } else {
             mWebView.addJavascriptInterface(new JsCallbackReceiver(this), JS_CALLBACK_HANDLER);
         }
-
-        mWebView.addJavascriptInterface(new NativeStateJsInterface(getActivity().getApplicationContext()),
-                                        JS_STATE_INTERFACE);
 
         mWebView.loadDataWithBaseURL("file:///android_asset/", htmlEditor, "text/html", "utf-8", "");
 
@@ -1273,29 +1272,6 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             // Insert closing tag
             content.insert(selectionEnd, endTag);
             mSourceViewContent.setSelection(selectionEnd + endTag.length());
-        }
-    }
-
-    private class NativeStateJsInterface {
-        Context mContext;
-
-        NativeStateJsInterface(Context context) {
-            mContext = context;
-        }
-
-        @JavascriptInterface
-        public String getStringEdit() {
-            return mContext.getString(R.string.edit);
-        }
-
-        @JavascriptInterface
-        public String getStringUploading() {
-            return mContext.getString(R.string.uploading);
-        }
-
-        @JavascriptInterface
-        public String getStringUploadingGallery() {
-            return mContext.getString(R.string.uploading_gallery_placeholder);
         }
     }
 }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -35,6 +35,7 @@ import org.json.JSONObject;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.JSONUtils;
+import org.wordpress.android.util.ProfilingUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
@@ -119,6 +120,9 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        ProfilingUtils.start("Visual Editor Startup");
+        ProfilingUtils.split("EditorFragment.onCreate");
     }
 
     @Override
@@ -369,6 +373,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         if (!isAdded()) {
             return;
         }
+
+        ProfilingUtils.split("EditorFragment.initJsEditor");
 
         String htmlEditor = Utils.getHtmlFromFile(getActivity(), "android-editor.html");
         if (htmlEditor != null) {
@@ -875,6 +881,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     }
 
     public void onDomLoaded() {
+        ProfilingUtils.split("EditorFragment.onDomLoaded");
+
         mWebView.post(new Runnable() {
             public void run() {
                 mDomHasLoaded = true;
@@ -931,6 +939,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
                     mWaitingGalleries.clear();
                 }
+
+                ProfilingUtils.split("EditorFragment.onDomLoaded completed");
+                ProfilingUtils.dump();
+                ProfilingUtils.stop();
             }
         });
     }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebViewAbstract.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebViewAbstract.java
@@ -36,6 +36,7 @@ public abstract class EditorWebViewAbstract extends WebView {
 
     private OnImeBackListener mOnImeBackListener;
     private AuthHeaderRequestListener mAuthHeaderRequestListener;
+    private JsCallbackReceiver mJsCallbackReceiver;
 
     private Map<String, String> mHeaderMap = new HashMap<>();
 
@@ -53,6 +54,12 @@ public abstract class EditorWebViewAbstract extends WebView {
         this.setWebViewClient(new WebViewClient() {
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                if (url != null && url.startsWith("callback") && mJsCallbackReceiver != null) {
+                    String[] split = url.split(":", 2);
+                    String callbackId = split[0];
+                    String params = (split.length > 1 ? split[1] : "");
+                    mJsCallbackReceiver.executeCallback(callbackId, params);
+                }
                 return true;
             }
 
@@ -176,6 +183,14 @@ public abstract class EditorWebViewAbstract extends WebView {
 
     public void setAuthHeaderRequestListener(AuthHeaderRequestListener listener) {
         mAuthHeaderRequestListener = listener;
+    }
+
+    /**
+     * Used on API<17 to handle callbacks as a safe alternative to JavascriptInterface (which has security risks
+     * at those API levels).
+     */
+    public void setJsCallbackReceiver(JsCallbackReceiver jsCallbackReceiver) {
+        mJsCallbackReceiver = jsCallbackReceiver;
     }
 
     @Override

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -41,9 +41,6 @@ ZSSEditor.caretInfo = { y: 0, height: 0 };
 // Is this device an iPad
 ZSSEditor.isiPad;
 
-// The API level of the native host (Android)
-ZSSEditor.androidApiLevel;
-
 // The current selection
 ZSSEditor.currentSelection;
 
@@ -78,8 +75,6 @@ ZSSEditor.videoShortcodeFormats = ["mp4", "m4v", "webm", "ogv", "wmv", "flv"];
 ZSSEditor.init = function() {
 
     rangy.init();
-
-    ZSSEditor.androidApiLevel = nativeState.getAPILevel();
 
     // Change a few CSS values if the device is an iPad
     ZSSEditor.isiPad = (navigator.userAgent.match(/iPad/i) != null);
@@ -232,7 +227,7 @@ ZSSEditor.callback = function(callbackScheme, callbackPath) {
 	if (isUsingiOS) {
         ZSSEditor.callbackThroughIFrame(url);
     } else if (isUsingAndroid) {
-        if (ZSSEditor.androidApiLevel < 17) {
+        if (nativeState.androidApiLevel < 17) {
             ZSSEditor.callbackThroughIFrame(url);
         } else {
             nativeCallbackHandler.executeCallback(callbackScheme, callbackPath);
@@ -861,7 +856,7 @@ ZSSEditor.insertLocalImage = function(imageNodeIdentifier, localImageUrl) {
     var progressIdentifier = this.getImageProgressIdentifier(imageNodeIdentifier);
     var imageContainerIdentifier = this.getImageContainerIdentifier(imageNodeIdentifier);
 
-    if (ZSSEditor.androidApiLevel > 18) {
+    if (nativeState.androidApiLevel > 18) {
         var imgContainerClass = 'img_container';
         var progressElement = '<progress id="' + progressIdentifier + '" value=0 class="wp_media_indicator" contenteditable="false"></progress>';
     } else {
@@ -2925,7 +2920,7 @@ ZSSField.prototype.callback = function(callbackScheme, callbackPath) {
     if (isUsingiOS) {
         ZSSEditor.callbackThroughIFrame(url);
     } else if (isUsingAndroid) {
-        if (ZSSEditor.androidApiLevel < 17) {
+        if (nativeState.androidApiLevel < 17) {
             ZSSEditor.callbackThroughIFrame(url);
         } else {
             nativeCallbackHandler.executeCallback(callbackScheme, callbackPath);

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -862,7 +862,7 @@ ZSSEditor.insertLocalImage = function(imageNodeIdentifier, localImageUrl) {
     } else {
         // Before API 19, the WebView didn't support progress tags. Use an upload overlay instead of a progress bar
         var imgContainerClass = 'img_container compat';
-        var progressElement = '<span class="upload-overlay" contenteditable="false">' + nativeState.getStringUploading()
+        var progressElement = '<span class="upload-overlay" contenteditable="false">' + nativeState.localizedStringUploading
                               + '</span><span class="upload-overlay-bg"></span>';
     }
 
@@ -1582,7 +1582,7 @@ ZSSEditor.applyImageSelectionFormatting = function( imageNode ) {
     }
 
     var overlay = '<span class="edit-overlay" contenteditable="false"><span class="edit-content">'
-                  + nativeState.getStringEdit() + '</span></span>';
+                  + nativeState.localizedStringEdit + '</span></span>';
 
     if (document.body.style.filter == null) {
         // CSS Filters (including blur) are not supported
@@ -2022,7 +2022,7 @@ ZSSEditor.insertGallery = function( imageIds, type, columns ) {
 
 ZSSEditor.insertLocalGallery = function( placeholderId ) {
     var container = '<span id="' + placeholderId + '" class="gallery_container">['
-                    + nativeState.getStringUploadingGallery() + ']</span>';
+                    + nativeState.localizedStringUploadingGallery + ']</span>';
     this.insertHTML(this.wrapInParagraphTags(container));
 }
 

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -232,7 +232,11 @@ ZSSEditor.callback = function(callbackScheme, callbackPath) {
 	if (isUsingiOS) {
         ZSSEditor.callbackThroughIFrame(url);
     } else if (isUsingAndroid) {
-        nativeCallbackHandler.executeCallback(callbackScheme, callbackPath);
+        if (ZSSEditor.androidApiLevel < 17) {
+            ZSSEditor.callbackThroughIFrame(url);
+        } else {
+            nativeCallbackHandler.executeCallback(callbackScheme, callbackPath);
+        }
 	} else {
 		console.log(url);
 	}
@@ -249,6 +253,7 @@ ZSSEditor.callback = function(callbackScheme, callbackPath) {
  */
 ZSSEditor.callbackThroughIFrame = function(url) {
     var iframe = document.createElement("IFRAME");
+    iframe.setAttribute('sandbox', '');
     iframe.setAttribute("src", url);
 
     // IMPORTANT: the IFrame was showing up as a black box below our text.  By setting its borders
@@ -2909,7 +2914,6 @@ ZSSField.prototype.sendVideoFullScreenEnded = function() {
 // MARK: - Callback Execution
 
 ZSSField.prototype.callback = function(callbackScheme, callbackPath) {
-
     var url = callbackScheme + ":";
 
     url = url + "id=" + this.getNodeId();
@@ -2921,7 +2925,11 @@ ZSSField.prototype.callback = function(callbackScheme, callbackPath) {
     if (isUsingiOS) {
         ZSSEditor.callbackThroughIFrame(url);
     } else if (isUsingAndroid) {
-        nativeCallbackHandler.executeCallback(callbackScheme, callbackPath);
+        if (ZSSEditor.androidApiLevel < 17) {
+            ZSSEditor.callbackThroughIFrame(url);
+        } else {
+            nativeCallbackHandler.executeCallback(callbackScheme, callbackPath);
+        }
     } else {
         console.log(url);
     }

--- a/libs/editor-common/assets/android-editor.html
+++ b/libs/editor-common/assets/android-editor.html
@@ -6,6 +6,7 @@
       <script type="text/javascript">
         var nativeState = new Object();
         nativeState.androidApiLevel=%%ANDROID_API_LEVEL%%;
+        %%LOCALIZED_STRING_INIT%%
     </script>
     <script src="jquery-2.1.3.min.js"></script>
     <script src="js-beautifier.js"></script>

--- a/libs/editor-common/assets/android-editor.html
+++ b/libs/editor-common/assets/android-editor.html
@@ -3,6 +3,10 @@
   <head>
     <title>%%TITLE%%</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=0">
+      <script type="text/javascript">
+        var nativeState = new Object();
+        nativeState.androidApiLevel=%%ANDROID_API_LEVEL%%;
+    </script>
     <script src="jquery-2.1.3.min.js"></script>
     <script src="js-beautifier.js"></script>
     <script src="underscore-min.js"></script>


### PR DESCRIPTION
Fixes #24.
- On `API<17`, replaced the `nativeCallbackHandler` `JavascriptInterface` with running JS callbacks through a sandboxed iframe, which are received by `WebViewClient.shouldOverrideUrlLoading` and piped through to the `JsCallbackReceiver`
- Dropped `NativeStateJsInterface` for all APIs. Instead, the native API level and localized Strings are injected when loading the `android-editor.html` file
- Added profiling markers to track editor startup time
