### PR TITLE
Issue/268 link dialog field text

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Looper;
@@ -16,6 +17,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.text.Editable;
 import android.text.SpannableString;
 import android.text.Spanned;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -573,6 +575,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             if (linkText == null || linkText.equals("")) {
                 linkText = linkUrl;
             }
+
+            if (TextUtils.isEmpty(Uri.parse(linkUrl).getScheme())) linkUrl = "http://" + linkUrl;
 
             if (mSourceView.getVisibility() == View.VISIBLE) {
                 Editable content = mSourceViewContent.getText();

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -513,7 +513,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             }
 
             linkDialogFragment.setArguments(dialogBundle);
-            linkDialogFragment.show(getFragmentManager(), "LinkDialogFragment");
+            linkDialogFragment.show(getFragmentManager(), LinkDialogFragment.class.getSimpleName());
         } else {
             if (v instanceof ToggleButton) {
                 onFormattingButtonClicked((ToggleButton) v);

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -485,6 +485,12 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
             Bundle dialogBundle = new Bundle();
 
+            // Pass potential URL from user clipboard
+            String clipboardUri = Utils.getUrlFromClipboard(getActivity());
+            if (clipboardUri != null) {
+                dialogBundle.putString(LinkDialogFragment.LINK_DIALOG_ARG_URL, clipboardUri);
+            }
+
             // Pass selected text to dialog
             if (mSourceView.getVisibility() == View.VISIBLE) {
                 // HTML mode

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -492,14 +492,14 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 mSelectionEnd = mSourceViewContent.getSelectionEnd();
 
                 String selectedText = mSourceViewContent.getText().toString().substring(mSelectionStart, mSelectionEnd);
-                dialogBundle.putString("linkText", selectedText);
+                dialogBundle.putString(LinkDialogFragment.LINK_DIALOG_ARG_TEXT, selectedText);
             } else {
                 // Visual mode
                 mGetSelectedTextCountDownLatch = new CountDownLatch(1);
                 mWebView.execJavaScriptFromString("ZSSEditor.execFunctionForResult('getSelectedText');");
                 try {
                     if (mGetSelectedTextCountDownLatch.await(1, TimeUnit.SECONDS)) {
-                        dialogBundle.putString("linkText", mJavaScriptResult);
+                        dialogBundle.putString(LinkDialogFragment.LINK_DIALOG_ARG_TEXT, mJavaScriptResult);
                     }
                 } catch (InterruptedException e) {
                     AppLog.d(T.EDITOR, "Failed to obtain selected text from JS editor.");
@@ -561,8 +561,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 return;
             }
 
-            String linkUrl = extras.getString("linkURL");
-            String linkText = extras.getString("linkText");
+            String linkUrl = extras.getString(LinkDialogFragment.LINK_DIALOG_ARG_URL);
+            String linkText = extras.getString(LinkDialogFragment.LINK_DIALOG_ARG_TEXT);
 
             if (linkText == null || linkText.equals("")) {
                 linkText = linkUrl;
@@ -1174,8 +1174,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
         Bundle dialogBundle = new Bundle();
 
-        dialogBundle.putString("linkURL", url);
-        dialogBundle.putString("linkText", title);
+        dialogBundle.putString(LinkDialogFragment.LINK_DIALOG_ARG_URL, url);
+        dialogBundle.putString(LinkDialogFragment.LINK_DIALOG_ARG_TEXT, title);
 
         linkDialogFragment.setArguments(dialogBundle);
         linkDialogFragment.show(getFragmentManager(), "LinkDialogFragment");

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/LinkDialogFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/LinkDialogFragment.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.EditText;
 
 public class LinkDialogFragment extends DialogFragment {
@@ -67,6 +68,9 @@ public class LinkDialogFragment extends DialogFragment {
             urlEditText.setSelection(urlEditText.length());
         }
 
-        return builder.create();
+        AlertDialog dialog =  builder.create();
+        dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+
+        return dialog;
     }
 }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/LinkDialogFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/LinkDialogFragment.java
@@ -65,7 +65,7 @@ public class LinkDialogFragment extends DialogFragment {
             if (url != null) {
                 urlEditText.setText(url);
             }
-            urlEditText.setSelection(urlEditText.length());
+            urlEditText.selectAll();
         }
 
         AlertDialog dialog =  builder.create();

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/LinkDialogFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/LinkDialogFragment.java
@@ -16,6 +16,9 @@ public class LinkDialogFragment extends DialogFragment {
     public static final int LINK_DIALOG_REQUEST_CODE_UPDATE = 2;
     public static final int LINK_DIALOG_REQUEST_CODE_DELETE = 3;
 
+    public static final String LINK_DIALOG_ARG_URL  = "linkURL";
+    public static final String LINK_DIALOG_ARG_TEXT = "linkText";
+
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
@@ -31,8 +34,8 @@ public class LinkDialogFragment extends DialogFragment {
                     @Override
                     public void onClick(DialogInterface dialog, int id) {
                         Intent intent = new Intent();
-                        intent.putExtra("linkURL", urlEditText.getText().toString());
-                        intent.putExtra("linkText", linkEditText.getText().toString());
+                        intent.putExtra(LINK_DIALOG_ARG_URL, urlEditText.getText().toString());
+                        intent.putExtra(LINK_DIALOG_ARG_TEXT, linkEditText.getText().toString());
                         getTargetFragment().onActivityResult(getTargetRequestCode(), getTargetRequestCode(), intent);
                     }
                 })
@@ -55,9 +58,9 @@ public class LinkDialogFragment extends DialogFragment {
         // Prepare initial state of EditTexts
         Bundle bundle = getArguments();
         if (bundle != null) {
-            linkEditText.setText(bundle.getString("linkText"));
+            linkEditText.setText(bundle.getString(LINK_DIALOG_ARG_TEXT));
 
-            String url = bundle.getString("linkURL");
+            String url = bundle.getString(LINK_DIALOG_ARG_URL);
             if (url != null) {
                 urlEditText.setText(url);
             }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/Utils.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/Utils.java
@@ -1,9 +1,12 @@
 package org.wordpress.android.editor;
 
 import android.app.Activity;
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.res.AssetManager;
 import android.net.Uri;
+import android.util.Patterns;
 
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.HTTPUtils;
@@ -221,5 +224,19 @@ public class Utils {
         } else {
             return null;
         }
+    }
+
+    /**
+     * Checks the Clipboard for text that matches the {@link Patterns#WEB_URL} pattern.
+     *
+     * @return the URL text in the clipboard, if it exists; otherwise null
+     */
+    public static String getUrlFromClipboard(Context context) {
+        if (context == null) return null;
+        ClipboardManager clipboard = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
+        ClipData data = clipboard != null ? clipboard.getPrimaryClip() : null;
+        if (data == null || data.getItemCount() <= 0) return null;
+        String clipText = String.valueOf(data.getItemAt(0).getText());
+        return Patterns.WEB_URL.matcher(clipText).matches() ? clipText : null;
     }
 }

--- a/WordPressEditor/src/main/res/layout/dialog_link.xml
+++ b/WordPressEditor/src/main/res/layout/dialog_link.xml
@@ -15,7 +15,6 @@
             android:layout_marginRight="@dimen/link_dialog_margin_outer"
             android:layout_marginBottom="@dimen/link_dialog_margin_inner"
             android:hint="@string/link_enter_url"
-            android:text="http://"
             android:imeOptions="actionNext"
             tools:ignore="HardcodedText"/>
 


### PR DESCRIPTION
Fix #268 by removing the default `http://` string from the URL field and filling in any existing clipboard URL.

Additionally 4e51cf8c413e248702ada791d2a4d11530422417 changes the selection of the URL field from the end of the text to selecting all text. This seems more useful (user can quickly delete if desired) and better aligns the Android functionality with iOS (iOS field has a delete all button).

I noticed the keyboard was not showing if it was hidden when pressing the Link button. d6d5868c123ff4c3004865015a8b21bba76325a4 will ensure that the keyboard is always shown when the dialog is displayed.

One more question before merging is in the issue, copied here for convenience:

> After toying around I think it would be nice if the link text field would auto-fill with whatever text your cursor is in the middle of. Currently it will only fill that field if text is highlighted. Thoughts?
