### PR TITLE
Fix a rare crash

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -925,6 +925,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
         mWebView.post(new Runnable() {
             public void run() {
+                if (!isAdded()) {
+                    return;
+                }
+
                 mDomHasLoaded = true;
 
                 mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_content').setMultiline('true');");


### PR DESCRIPTION
This crash is easy to reproduce on Android N, by resizing the window several times. Ref. https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/316#issuecomment-198454879
