### PR TITLE
Fix #314: Cursor jumping when switching from HTML to visual

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -453,7 +453,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 // Update the list of failed media uploads
                 mWebView.execJavaScriptFromString("ZSSEditor.getFailedMedia();");
 
-                mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_content').focus();");
+                // Reset selection to avoid buggy cursor behavior
+                mWebView.execJavaScriptFromString("ZSSEditor.resetSelectionOnField('zss_field_content');");
             }
         } else if (id == R.id.format_bar_button_media) {
             mEditorFragmentListener.onTrackableEvent(TrackableEvent.MEDIA_BUTTON_TAPPED);

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -376,6 +376,18 @@ ZSSEditor.restoreRange = function(){
     }
 };
 
+ZSSEditor.resetSelectionOnField = function(fieldId) {
+    var query = "div#" + fieldId;
+    var field = document.querySelector(query);
+    var range = document.createRange();
+    range.setStart(field, 0);
+    range.setEnd(field, 0);
+
+    var selection = document.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+};
+
 ZSSEditor.getSelectedText = function() {
 	var selection = window.getSelection();
 


### PR DESCRIPTION
Fixes #314 by resetting the selection when returning from HTML mode to visual.

cc @maxme
