### PR TITLE
Sync WPAndroid subtree and fix broken tests

### DIFF
--- a/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/ZssEditorTest.java
+++ b/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/ZssEditorTest.java
@@ -93,7 +93,7 @@ public class ZssEditorTest extends ActivityInstrumentationTestCase2<MockActivity
         Set<String> expectedSet = new HashSet<>();
         expectedSet.add("callback-new-field:id=zss_field_title");
         expectedSet.add("callback-new-field:id=zss_field_content");
-        expectedSet.add("callback-dom-loaded:undefined");
+        expectedSet.add("callback-dom-loaded:");
 
         assertEquals(expectedSet, mCallbackSet);
     }
@@ -113,10 +113,12 @@ public class ZssEditorTest extends ActivityInstrumentationTestCase2<MockActivity
             // Handle callbacks and count down latches according to the currently running test
             switch(mTestMethod) {
                 case INIT:
-                    if (callbackId.equals("callback-new-field") || callbackId.equals("callback-dom-loaded")) {
+                    if (callbackId.equals("callback-dom-loaded")) {
+                        mCallbackSet.add(callbackId + ":");
+                    } else if (callbackId.equals("callback-new-field")) {
                         mCallbackSet.add(callbackId + ":" + params);
-                        mCallbackLatch.countDown();
                     }
+                    mCallbackLatch.countDown();
                     break;
                 default:
                     throw(new RuntimeException("Unknown calling method"));

--- a/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/ZssEditorTest.java
+++ b/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/ZssEditorTest.java
@@ -65,7 +65,12 @@ public class ZssEditorTest extends ActivityInstrumentationTestCase2<MockActivity
             @Override
             public void run() {
                 mWebView = new EditorWebView(mInstrumentation.getContext(), null);
-                mWebView.addJavascriptInterface(new MockJsCallbackReceiver(), JS_CALLBACK_HANDLER);
+                if (Build.VERSION.SDK_INT < 17) {
+                    mWebView.setJsCallbackReceiver(new MockJsCallbackReceiver(new EditorFragmentForTests()));
+                } else {
+                    mWebView.addJavascriptInterface(new MockJsCallbackReceiver(new EditorFragmentForTests()),
+                            JS_CALLBACK_HANDLER);
+                }
                 mWebView.loadDataWithBaseURL("file:///android_asset/", finalHtmlEditor, "text/html", "utf-8", "");
                 mSetUpLatch.countDown();
             }
@@ -93,7 +98,11 @@ public class ZssEditorTest extends ActivityInstrumentationTestCase2<MockActivity
         assertEquals(expectedSet, mCallbackSet);
     }
 
-    private class MockJsCallbackReceiver {
+    private class MockJsCallbackReceiver extends JsCallbackReceiver {
+        public MockJsCallbackReceiver(EditorFragmentAbstract editorFragmentAbstract) {
+            super(editorFragmentAbstract);
+        }
+
         @JavascriptInterface
         public void executeCallback(String callbackId, String params) {
             if (callbackId.equals("callback-dom-loaded")) {

--- a/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/ZssEditorTest.java
+++ b/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/ZssEditorTest.java
@@ -3,6 +3,7 @@ package org.wordpress.android.editor;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Instrumentation;
+import android.os.Build;
 import android.test.ActivityInstrumentationTestCase2;
 import android.webkit.JavascriptInterface;
 
@@ -46,13 +47,26 @@ public class ZssEditorTest extends ActivityInstrumentationTestCase2<MockActivity
 
         mSetUpLatch.countDown();
 
-        final String htmlEditor = Utils.getHtmlFromFile(activity, "android-editor.html");
+        String htmlEditor = Utils.getHtmlFromFile(activity, "android-editor.html");
+
+        if (htmlEditor != null) {
+            htmlEditor = htmlEditor.replace("%%TITLE%%", getActivity().getString(R.string.visual_editor));
+            htmlEditor = htmlEditor.replace("%%ANDROID_API_LEVEL%%", String.valueOf(Build.VERSION.SDK_INT));
+            htmlEditor = htmlEditor.replace("%%LOCALIZED_STRING_INIT%%",
+                    "nativeState.localizedStringEdit = '" + getActivity().getString(R.string.edit) + "';\n" +
+                    "nativeState.localizedStringUploading = '" + getActivity().getString(R.string.uploading) + "';\n" +
+                    "nativeState.localizedStringUploadingGallery = '" +
+                            getActivity().getString(R.string.uploading_gallery_placeholder) + "';\n");
+        }
+
+        final String finalHtmlEditor = htmlEditor;
+
         activity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 mWebView = new EditorWebView(mInstrumentation.getContext(), null);
                 mWebView.addJavascriptInterface(new MockJsCallbackReceiver(), JS_CALLBACK_HANDLER);
-                mWebView.loadDataWithBaseURL("file:///android_asset/", htmlEditor, "text/html", "utf-8", "");
+                mWebView.loadDataWithBaseURL("file:///android_asset/", finalHtmlEditor, "text/html", "utf-8", "");
                 mSetUpLatch.countDown();
             }
         });

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -821,6 +821,11 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     }
 
     @Override
+    public void removeAllFailedMediaUploads() {
+        mWebView.execJavaScriptFromString("ZSSEditor.removeAllFailedMediaUploads();");
+    }
+
+    @Override
     public Spanned getSpannedContent() {
         return null;
     }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -22,6 +22,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
     public abstract void setUrlForVideoPressId(String videoPressId, String url, String posterUrl);
     public abstract boolean isUploadingMedia();
     public abstract boolean hasFailedMediaUploads();
+    public abstract void removeAllFailedMediaUploads();
     public abstract void setTitlePlaceholder(CharSequence text);
     public abstract void setContentPlaceholder(CharSequence text);
 

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
@@ -1144,6 +1144,9 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
     }
 
     @Override
+    public void removeAllFailedMediaUploads() {}
+
+    @Override
     public void setTitlePlaceholder(CharSequence text) {
 
     }

--- a/WordPressEditor/src/test/java/org/wordpress/android/editor/EditorFragmentAbstractTest.java
+++ b/WordPressEditor/src/test/java/org/wordpress/android/editor/EditorFragmentAbstractTest.java
@@ -85,6 +85,11 @@ public class EditorFragmentAbstractTest {
         }
 
         @Override
+        public void removeAllFailedMediaUploads() {
+
+        }
+
+        @Override
         public void setTitlePlaceholder(CharSequence text) {
 
         }

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -241,14 +241,18 @@ ZSSEditor.onMutationObserved = function(mutations) {
                 var mediaIdentifier = removedNode.attributes.getNamedItem("data-wpid").value;
                 var parentRange = ZSSEditor.getParentRangeOfFocusedNode();
                 ZSSEditor.removeImage(mediaIdentifier);
-                ZSSEditor.setRange(parentRange);
+                if (parentRange != null) {
+                    ZSSEditor.setRange(parentRange);
+                }
                 ZSSEditor.sendMediaRemovedCallback(mediaIdentifier);
             } else if (removedNode.attributes.getNamedItem("data-video_wpid")) {
                 // An uploading or failed video was deleted manually - remove its container and send the callback
                 var mediaIdentifier = removedNode.attributes.getNamedItem("data-video_wpid").value;
                 var parentRange = ZSSEditor.getParentRangeOfFocusedNode();
                 ZSSEditor.removeVideo(mediaIdentifier);
-                ZSSEditor.setRange(parentRange);
+                if (parentRange != null) {
+                    ZSSEditor.setRange(parentRange);
+                }
                 ZSSEditor.sendMediaRemovedCallback(mediaIdentifier);
             }
         }
@@ -2778,6 +2782,9 @@ ZSSEditor.parentTags = function() {
 
 ZSSEditor.getParentRangeOfFocusedNode = function() {
     var selection = window.getSelection();
+    if (selection.focusNode == null) {
+        return null;
+    }
     return selection.getRangeAt(selection.focusNode.parentNode);
 };
 


### PR DESCRIPTION
Fixes unit tests broken by an unimplemented `EditorFragmentAbstract` method, as well as an integration test that broke because the `%%...%%` placeholders in `android-editor.html` weren't being replaced in the test.

cc @maxme
