### PR TITLE
Issue #292: Buggy autocorrect when using backspace on API 19+

### DIFF
--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -474,7 +474,7 @@ ZSSEditor.getYCaretInfo = function() {
     //
     if (needsToWorkAroundNewlineBug) {
         var closerParentNode = ZSSEditor.closerParentNode();
-        var closerDiv = ZSSEditor.closerParentNodeWithName('div');
+        var closerDiv = ZSSEditor.findParentContenteditableDiv();
 
         var fontSize = $(closerParentNode).css('font-size');
         var lineHeight = Math.floor(parseInt(fontSize.replace('px','')) * 1.5);

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -191,26 +191,7 @@ ZSSEditor.getField = function(fieldId) {
 };
 
 ZSSEditor.getFocusedField = function() {
-    var currentField = $(this.closerParentNodeWithName('div'));
-    var currentFieldId;
-
-    if (currentField) {
-        currentFieldId = currentField.attr('id');
-    }
-
-    while (currentField && (!currentFieldId || this.editableFields[currentFieldId] == null)) {
-        currentField = this.closerParentNodeStartingAtNode('div', currentField);
-        if (currentField) {
-            currentFieldId = currentField.attr('id');
-        }
-    }
-
-    if (!currentFieldId) {
-        ZSSEditor.resetSelectionOnField('zss_field_content');
-        currentFieldId = 'zss_field_content';
-    }
-
-    return this.editableFields[currentFieldId];
+    return this.focusedField;
 };
 
 ZSSEditor.execFunctionForResult = function(methodName) {
@@ -2294,7 +2275,7 @@ ZSSEditor.removeVisualFormatting = function( html ) {
     str = ZSSEditor.replaceVideoPressVideosForShortcode( str );
     str = ZSSEditor.replaceVideosForShortcode( str );
     return str;
-}
+};
 
 ZSSEditor.insertHTML = function(html) {
 	document.execCommand('insertHTML', false, html);

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -63,7 +63,7 @@ ZSSEditor.editableFields = {};
 ZSSEditor.lastTappedNode = null;
 
 // The default paragraph separator
-ZSSEditor.defaultParagraphSeparator = 'p';
+ZSSEditor.defaultParagraphSeparator = 'div';
 
 // Video format tags supported by the [video] shortcode: https://codex.wordpress.org/Video_Shortcode
 // mp4, m4v and webm prioritized since they're supported by the stock player as of Android API 23
@@ -92,7 +92,6 @@ ZSSEditor.init = function() {
     }
 
     document.execCommand('insertBrOnReturn', false, false);
-    document.execCommand('defaultParagraphSeparator', false, this.defaultParagraphSeparator);
 
     var editor = $('div.field').each(function() {
         var editableField = new ZSSField($(this));
@@ -172,7 +171,7 @@ ZSSEditor.formatNewLine = function(e) {
             this.formatNewLineInsideBlockquote(e);
         } else if (!ZSSEditor.isCommandEnabled('insertOrderedList')
                    && !ZSSEditor.isCommandEnabled('insertUnorderedList')) {
-            document.execCommand('formatBlock', false, 'p');
+            document.execCommand('formatBlock', false, 'div');
         }
     } else {
         e.preventDefault();
@@ -654,7 +653,7 @@ ZSSEditor.setHeading = function(heading) {
 };
 
 ZSSEditor.setParagraph = function() {
-	var formatTag = "p";
+	var formatTag = "div";
 	var formatBlock = document.queryCommandValue('formatBlock');
 
 	if (formatBlock.length > 0 && formatBlock.toLowerCase() == formatTag) {
@@ -3252,7 +3251,7 @@ ZSSField.prototype.wrapCaretInParagraphIfNecessary = function()
             var range = selection.getRangeAt(0);
 
             if (range.startContainer == range.endContainer) {
-                var paragraph = document.createElement("p");
+                var paragraph = document.createElement("div");
                 var textNode = document.createTextNode("&#x200b;");
 
                 paragraph.appendChild(textNode);

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3271,7 +3271,11 @@ ZSSField.prototype.isEmpty = function() {
 };
 
 ZSSField.prototype.getHTML = function() {
-    var html = wp.saveText(this.wrappedObject.html());
+    var html = this.wrappedObject.html();
+    if (ZSSEditor.defaultParagraphSeparator == 'div') {
+        html = html.replace(/(<div)/igm, '<p').replace(/<\/div>/igm, '</p>');
+    }
+    html = wp.saveText(html);
     html = ZSSEditor.removeVisualFormatting( html );
     return html;
 };
@@ -3298,6 +3302,12 @@ ZSSField.prototype.setHTML = function(html) {
     ZSSEditor.currentEditingImage = null;
     var mutatedHTML = wp.loadText(html);
     mutatedHTML = ZSSEditor.applyVisualFormatting(mutatedHTML);
+
+    if (ZSSEditor.defaultParagraphSeparator == 'div') {
+        // Replace the paragraph tags we get from wpload with divs
+        mutatedHTML = mutatedHTML.replace(/(<p)/igm, '<div').replace(/<\/p>/igm, '</div>');
+    }
+
     this.wrappedObject.html(mutatedHTML);
 };
 

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -26,7 +26,9 @@ const NodeName = {
     LI: "LI",
     CODE: "CODE",
     SPAN: "SPAN",
-    BR: "BR"
+    BR: "BR",
+    DIV: "DIV",
+    BODY: "BODY"
 };
 
 // The editor object
@@ -2604,7 +2606,9 @@ ZSSEditor.getAncestorElementForSettingBlockquote = function(range) {
                || parentElement.nodeName == NodeName.OL
                || parentElement.nodeName == NodeName.LI
                || parentElement.nodeName == NodeName.CODE
-               || parentElement.nodeName == NodeName.SPAN)) {
+               || parentElement.nodeName == NodeName.SPAN
+               // Include nested divs, but ignore the parent contenteditable field div
+               || (parentElement.nodeName == NodeName.DIV && parentElement.parentElement.nodeName != NodeName.BODY))) {
         parentElement = parentElement.parentNode;
     }
 

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -193,7 +193,19 @@ ZSSEditor.getField = function(fieldId) {
 };
 
 ZSSEditor.getFocusedField = function() {
-    return this.focusedField;
+    var currentField = $(this.findParentContenteditableDiv());
+    var currentFieldId;
+
+    if (currentField) {
+        currentFieldId = currentField.attr('id');
+    }
+
+    if (!currentFieldId) {
+        ZSSEditor.resetSelectionOnField('zss_field_content');
+        currentFieldId = 'zss_field_content';
+    }
+
+    return this.editableFields[currentFieldId];
 };
 
 ZSSEditor.execFunctionForResult = function(methodName) {
@@ -2729,6 +2741,23 @@ ZSSEditor.hasPreviousSiblingWithName = function(node, siblingNodeName) {
 
 
 // MARK: - Parent nodes & tags
+
+ZSSEditor.findParentContenteditableDiv = function() {
+    var parentNode = null;
+    var selection = window.getSelection();
+    if (selection.rangeCount < 1) {
+        return null;
+    }
+    var range = selection.getRangeAt(0).cloneRange();
+
+    var referenceNode = this.closerParentNodeWithNameRelativeToNode('div', range.commonAncestorContainer);
+
+    while (referenceNode.parentNode.nodeName != NodeName.BODY) {
+        referenceNode = this.closerParentNodeWithNameRelativeToNode('div', referenceNode.parentNode);
+    }
+
+    return referenceNode;
+};
 
 ZSSEditor.closerParentNode = function() {
 

--- a/libs/editor-common/assets/editor-android.css
+++ b/libs/editor-common/assets/editor-android.css
@@ -16,6 +16,15 @@ video::-webkit-media-controls-fullscreen-button {
     display: none;
 }
 
+/* Duplicates paragraph tag formatting for div tags, which are needed on Android API 19+ due to autocorrect issues:
+https://bugs.chromium.org/p/chromium/issues/detail?id=599890
+*/
+div:not(.field):not(#separatorDiv) {
+    line-height: 24px;
+    margin-top: 0px;
+    margin-bottom: 24px;
+}
+
 /* --- API<19 workarounds --- */
 
 /* Used only on older APIs (API<19), which don't support CSS filter effects (specifically, blur). */


### PR DESCRIPTION
Fixes #292 (word in progress).

Uses `div` instead of `p` as the paragraph separator within the editor. Not yet complete: blockquotes are badly broken and further testing is needed on older APIs and in edge cases. This PR introduces a pretty fundamental change to editor internals, and could have any number of side effects. We'll need to test thoroughly before merging this branch, even once all current known issues are fixed.

<h4>TODO</h4>
- [x] Fix blockquotes, they're pretty badly broken by these changes
- [x] Fully test lists and all other formatting
- [x] Check older APIs throughly - if we run into issues we may need to limit these changes to `API 19+` and keep using `p` separators for older APIs (the bug only occurs on `API 19+` anyway)
- [x] Check Android N (with its beta WebView)
- [x] Make sure hardware keyboards work correctly
  - [x] Emulators
  - [x] Marshmallow devices
  - [x] Pre-API19 devices
  - [x] Android N
- [x] Make sure the `ZSSEditor.getFocusedField()` simplification doesn't break anything
- [x] Investigate zero-width space behavior: it seemed safe to remove it (and thus fix #230) when using `p` tags, but I haven't been able to get rid of zero-width space when using `div` tags without causing issues. While they're not an issue for `API 22+`, #230 is a pretty bad bug for Kit Kat users. It's not clear that we should implement the fix in this PR for KitKat, if it means blocking us from fixing #230. This needs some further thought/research.

<h4>Details/backstory</h4>


Some false positive results at first suggested that the issue was caused by the zero-width space character [we're using](https://github.com/wordpress-mobile/WordPress-Editor-Android/blob/5e905787de707b4c43dc6cadedebbd315980bf35/libs/editor-common/assets/ZSSRichTextEditor.js#L3256), which is also the cause of [this bug](https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/230) on API 19-21. That turns out not to be the case. The takeaway is to vary the test words/sequences used when testing, because autocorrect can learn your sequence and stop trying to correct it when you backspace, giving a false positive result when in fact the bug is still present.

The real culprit is a bug in the Android WebView (or the autocorrect/software keyboard, or all of them). By default, paragraphs are separated using divs in the WebView, but this was changed in the editor from iOS to fix some paragraph styling/caret issues: https://github.com/wordpress-mobile/WordPress-Editor-iOS/pull/319.

The change was made using:

``` javascript
document.execCommand('defaultParagraphSeparator', false, 'p');
```

While this method is implemented on Android, it causes issues with autocorrect, at least when using the default keyboard. I opened a ticket in the Chromium project about this, with a basic demo project showcasing the bug. If a fix comes out for this in the future we may be able to revert this PR (if we even merge it), and keep `p` tags.

Chromium project ticket: https://bugs.chromium.org/p/chromium/issues/detail?id=599890
