### PR TITLE
Fix #340: Wrap links in a new paragraph when the post is empty

### DIFF
--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -813,7 +813,13 @@ ZSSEditor.insertHTMLWrappedInParagraphTags = function(html) {
 // Needs addClass method
 
 ZSSEditor.insertLink = function(url, title) {
-    this.insertHTML('<a href="' + url + '">' + title + "</a>");
+    var html = '<a href="' + url + '">' + title + "</a>";
+
+    if (this.getFocusedField().getHTML().length == 0) {
+        html = '<' + this.defaultParagraphSeparator + '>' + html;
+    }
+
+    this.insertHTML(html);
 };
 
 ZSSEditor.updateLink = function(url, title) {


### PR DESCRIPTION
Fixes #340, wrapping links in paragraph tags when they're added to an empty post.

cc @maxme
