### PR TITLE
Feature #290: Optimistic upload progress

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1117,14 +1117,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                             case IMAGE:
                                 mWebView.execJavaScriptFromString("ZSSEditor.unmarkImageUploadFailed(" + mediaId
                                         + ");");
-                                mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + mediaId + ", "
-                                        + 0 + ");");
                                 break;
                             case VIDEO:
                                 mWebView.execJavaScriptFromString("ZSSEditor.unmarkVideoUploadFailed(" + mediaId
                                         + ");");
-                                mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnVideo(" + mediaId + ", "
-                                        + 0 + ");");
                         }
                         mFailedMediaIds.remove(mediaId);
                         mUploadingMedia.put(mediaId, mediaType);

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -899,13 +899,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 @Override
                 public void run() {
                     String progressString = String.format(Locale.US, "%.1f", progress);
-                    if (mediaType.equals(MediaType.IMAGE)) {
-                        mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + mediaId + ", " +
-                                progressString + ");");
-                    } else if (mediaType.equals(MediaType.VIDEO)) {
-                        mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnVideo(" + mediaId + ", " +
-                                progressString + ");");
-                    }
+                    mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnMedia(" + mediaId + ", " +
+                            progressString + ");");
                 }
             });
         }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -793,12 +793,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                         String posterUrl = Utils.escapeQuotes(StringUtils.notNullStr(mediaFile.getThumbnailURL()));
                         mWebView.execJavaScriptFromString("ZSSEditor.insertLocalVideo(" + id + ", '" + posterUrl +
                                 "');");
-                        mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnVideo(" + id + ", " + 0 + ");");
                         mUploadingMedia.put(id, MediaType.VIDEO);
                     } else {
                         mWebView.execJavaScriptFromString("ZSSEditor.insertLocalImage(" + id + ", '" + safeMediaUrl +
                                 "');");
-                        mWebView.execJavaScriptFromString("ZSSEditor.setProgressOnImage(" + id + ", " + 0 + ");");
                         mUploadingMedia.put(id, MediaType.IMAGE);
                     }
                 }

--- a/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
+++ b/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
@@ -34,6 +34,7 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
 
     public static final int ADD_MEDIA_ACTIVITY_REQUEST_CODE = 1111;
     public static final int ADD_MEDIA_FAIL_ACTIVITY_REQUEST_CODE = 1112;
+    public static final int ADD_MEDIA_SLOW_NETWORK_REQUEST_CODE = 1113;
 
     public static final String MEDIA_REMOTE_ID_SAMPLE = "123";
 
@@ -41,6 +42,7 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
     private static final int SELECT_IMAGE_FAIL_MENU_POSITION = 1;
     private static final int SELECT_VIDEO_MENU_POSITION = 2;
     private static final int SELECT_VIDEO_FAIL_MENU_POSITION = 3;
+    private static final int SELECT_IMAGE_SLOW_MENU_POSITION = 4;
 
     private EditorFragmentAbstract mEditorFragment;
 
@@ -85,6 +87,7 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
         menu.add(0, SELECT_IMAGE_FAIL_MENU_POSITION, 0, getString(R.string.select_image_fail));
         menu.add(0, SELECT_VIDEO_MENU_POSITION, 0, getString(R.string.select_video));
         menu.add(0, SELECT_VIDEO_FAIL_MENU_POSITION, 0, getString(R.string.select_video_fail));
+        menu.add(0, SELECT_IMAGE_SLOW_MENU_POSITION, 0, getString(R.string.select_image_slow_network));
     }
 
     @Override
@@ -120,6 +123,13 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
 
                 startActivityForResult(intent, ADD_MEDIA_FAIL_ACTIVITY_REQUEST_CODE);
                 return true;
+            case SELECT_IMAGE_SLOW_MENU_POSITION:
+                intent.setType("image/*");
+                intent.setAction(Intent.ACTION_GET_CONTENT);
+                intent = Intent.createChooser(intent, getString(R.string.select_image_slow_network));
+
+                startActivityForResult(intent, ADD_MEDIA_SLOW_NETWORK_REQUEST_CODE);
+                return true;
             default:
                 return false;
         }
@@ -154,6 +164,14 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
                 if (mEditorFragment instanceof EditorMediaUploadListener) {
                     simulateFileUploadFail(mediaId, imageUri.toString());
                 }
+                break;
+            case ADD_MEDIA_SLOW_NETWORK_REQUEST_CODE:
+                mEditorFragment.appendMediaFile(mediaFile, imageUri.toString(), null);
+
+                if (mEditorFragment instanceof EditorMediaUploadListener) {
+                    simulateSlowFileUpload(mediaId, imageUri.toString());
+                }
+                break;
         }
     }
 
@@ -272,6 +290,39 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
                             getString(R.string.tap_to_try_again));
 
                     mFailedUploads.put(mediaId, mediaUrl);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        };
+
+        thread.start();
+    }
+
+    private void simulateSlowFileUpload(final String mediaId, final String mediaUrl) {
+        Thread thread = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    sleep(5000);
+                    float count = (float) 0.1;
+                    while (count < 1.1) {
+                        sleep(2000);
+
+                        ((EditorMediaUploadListener) mEditorFragment).onMediaUploadProgress(mediaId, count);
+
+                        count += 0.1;
+                    }
+
+                    MediaFile mediaFile = new MediaFile();
+                    mediaFile.setMediaId(MEDIA_REMOTE_ID_SAMPLE);
+                    mediaFile.setFileURL(mediaUrl);
+
+                    ((EditorMediaUploadListener) mEditorFragment).onMediaUploadSucceeded(mediaId, mediaFile);
+
+                    if (mFailedUploads.containsKey(mediaId)) {
+                        mFailedUploads.remove(mediaId);
+                    }
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }

--- a/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
+++ b/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
@@ -143,33 +143,33 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
             return;
         }
 
-        Uri imageUri = data.getData();
+        Uri mediaUri = data.getData();
 
         MediaFile mediaFile = new MediaFile();
         String mediaId = String.valueOf(System.currentTimeMillis());
         mediaFile.setMediaId(mediaId);
-        mediaFile.setVideo(imageUri.toString().contains("video"));
+        mediaFile.setVideo(mediaUri.toString().contains("video"));
 
         switch (requestCode) {
             case ADD_MEDIA_ACTIVITY_REQUEST_CODE:
-                mEditorFragment.appendMediaFile(mediaFile, imageUri.toString(), null);
+                mEditorFragment.appendMediaFile(mediaFile, mediaUri.toString(), null);
 
                 if (mEditorFragment instanceof EditorMediaUploadListener) {
-                    simulateFileUpload(mediaId, imageUri.toString());
+                    simulateFileUpload(mediaId, mediaUri.toString());
                 }
                 break;
             case ADD_MEDIA_FAIL_ACTIVITY_REQUEST_CODE:
-                mEditorFragment.appendMediaFile(mediaFile, imageUri.toString(), null);
+                mEditorFragment.appendMediaFile(mediaFile, mediaUri.toString(), null);
 
                 if (mEditorFragment instanceof EditorMediaUploadListener) {
-                    simulateFileUploadFail(mediaId, imageUri.toString());
+                    simulateFileUploadFail(mediaId, mediaUri.toString());
                 }
                 break;
             case ADD_MEDIA_SLOW_NETWORK_REQUEST_CODE:
-                mEditorFragment.appendMediaFile(mediaFile, imageUri.toString(), null);
+                mEditorFragment.appendMediaFile(mediaFile, mediaUri.toString(), null);
 
                 if (mEditorFragment instanceof EditorMediaUploadListener) {
-                    simulateSlowFileUpload(mediaId, imageUri.toString());
+                    simulateSlowFileUpload(mediaId, mediaUri.toString());
                 }
                 break;
         }

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
     <string name="select_image_fail">Select an image (failure demo)</string>
     <string name="select_video">Select a video</string>
     <string name="select_video_fail">Select a video (failure demo)</string>
+    <string name="select_image_slow_network">Select an image (slow network demo)</string>
 </resources>

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1068,6 +1068,8 @@ ZSSEditor.insertLocalImage = function(imageNodeIdentifier, localImageUrl) {
 
     ZSSEditor.trackNodeForMutation(this.getImageContainerNodeWithIdentifier(imageNodeIdentifier));
 
+    this.setProgressOnImage(imageNodeIdentifier, 0);
+
     this.sendEnabledStyles();
 };
 
@@ -1173,10 +1175,13 @@ ZSSEditor.tryToReload = function (image, imageNode, imageNodeIdentifier, remoteI
  */
 ZSSEditor.setProgressOnImage = function(imageNodeIdentifier, progress) {
     var imageNode = this.getImageNodeWithIdentifier(imageNodeIdentifier);
-    if (imageNode.length == 0){
+    var imageProgressNode = this.getImageProgressNodeWithIdentifier(imageNodeIdentifier);
+
+    if (imageNode.length == 0 || imageProgressNode.length == 0){
         return;
     }
-    if (progress < 1){
+
+    if (progress == 0) {
         imageNode.addClass("uploading");
     }
 
@@ -1186,10 +1191,6 @@ ZSSEditor.setProgressOnImage = function(imageNodeIdentifier, progress) {
         this.getImageContainerNodeWithIdentifier(imageNodeIdentifier).removeClass("compat");
     }
 
-    var imageProgressNode = this.getImageProgressNodeWithIdentifier(imageNodeIdentifier);
-    if (imageProgressNode.length == 0){
-          return;
-    }
     imageProgressNode.attr("value",progress);
 };
 
@@ -1398,6 +1399,8 @@ ZSSEditor.insertLocalVideo = function(videoNodeIdentifier, posterURL) {
 
     ZSSEditor.trackNodeForMutation(this.getVideoContainerNodeWithIdentifier(videoNodeIdentifier));
 
+    this.setProgressOnVideo(videoNodeIdentifier, 0);
+
     this.sendEnabledStyles();
 };
 
@@ -1470,10 +1473,13 @@ ZSSEditor.replaceLocalVideoWithRemoteVideo = function(videoNodeIdentifier, remot
  */
 ZSSEditor.setProgressOnVideo = function(videoNodeIdentifier, progress) {
     var videoNode = this.getVideoNodeWithIdentifier(videoNodeIdentifier);
-    if (videoNode.length == 0){
+    var videoProgressNode = this.getVideoProgressNodeWithIdentifier(videoNodeIdentifier);
+
+    if (videoNode.length == 0 || videoProgressNode.length == 0){
         return;
     }
-    if (progress < 1){
+
+    if (progress == 0) {
         videoNode.addClass("uploading");
     }
 
@@ -1484,10 +1490,6 @@ ZSSEditor.setProgressOnVideo = function(videoNodeIdentifier, progress) {
         this.getVideoContainerNodeWithIdentifier(videoNodeIdentifier).removeClass("compat");
     }
 
-    var videoProgressNode = this.getVideoProgressNodeWithIdentifier(videoNodeIdentifier);
-    if (videoProgressNode.length == 0){
-        return;
-    }
     videoProgressNode.attr("value",progress);
 };
 

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -986,6 +986,24 @@ ZSSEditor.extractMediaIdentifier = function(node) {
     return "";
 };
 
+ZSSEditor.getMediaNodeWithIdentifier = function(mediaNodeIdentifier) {
+    var imageNode = ZSSEditor.getImageNodeWithIdentifier(mediaNodeIdentifier);
+    if (imageNode.length > 0) {
+        return imageNode;
+    } else {
+        return ZSSEditor.getVideoNodeWithIdentifier(mediaNodeIdentifier);
+    }
+};
+
+ZSSEditor.getMediaProgressNodeWithIdentifier = function(mediaNodeIdentifier) {
+    var imageProgressNode = ZSSEditor.getImageProgressNodeWithIdentifier(mediaNodeIdentifier);
+    if (imageProgressNode.length > 0) {
+        return imageProgressNode;
+    } else {
+        return ZSSEditor.getVideoProgressNodeWithIdentifier(mediaNodeIdentifier);
+    }
+};
+
 ZSSEditor.getMediaContainerNodeWithIdentifier = function(mediaNodeIdentifier) {
     var imageContainerNode = ZSSEditor.getImageContainerNodeWithIdentifier(mediaNodeIdentifier);
     if (imageContainerNode.length > 0) {
@@ -993,6 +1011,33 @@ ZSSEditor.getMediaContainerNodeWithIdentifier = function(mediaNodeIdentifier) {
     } else {
         return ZSSEditor.getVideoContainerNodeWithIdentifier(mediaNodeIdentifier);
     }
+};
+
+/**
+ *  @brief      Update the progress indicator for the media item identified with the value in progress.
+ *
+ *  @param      mediaNodeIdentifier This is a unique ID provided by the caller.
+ *  @param      progress    A value between 0 and 1 indicating the progress on the media upload.
+ */
+ZSSEditor.setProgressOnMedia = function(mediaNodeIdentifier, progress) {
+    var mediaNode = this.getMediaNodeWithIdentifier(mediaNodeIdentifier);
+    var mediaProgressNode = this.getMediaProgressNodeWithIdentifier(mediaNodeIdentifier);
+
+    if (mediaNode.length == 0 || mediaProgressNode.length == 0){
+        return;
+    }
+
+    if (progress == 0) {
+        mediaNode.addClass("uploading");
+    }
+
+    // Revert to non-compatibility image container once image upload has begun. This centers the overlays on the image
+    // (instead of the screen), while still circumventing the small container bug the compat class was added to fix
+    if (progress > 0) {
+        this.getMediaContainerNodeWithIdentifier(mediaNodeIdentifier).removeClass("compat");
+    }
+
+    mediaProgressNode.attr("value", progress);
 };
 
 ZSSEditor.sendMediaRemovedCallback = function(mediaNodeIdentifier) {
@@ -1122,7 +1167,7 @@ ZSSEditor.insertLocalImage = function(imageNodeIdentifier, localImageUrl) {
 
     ZSSEditor.trackNodeForMutation(this.getImageContainerNodeWithIdentifier(imageNodeIdentifier));
 
-    this.setProgressOnImage(imageNodeIdentifier, 0);
+    this.setProgressOnMedia(imageNodeIdentifier, 0);
 
     this.sendEnabledStyles();
 };
@@ -1220,33 +1265,6 @@ ZSSEditor.tryToReload = function (image, imageNode, imageNodeIdentifier, remoteI
     // reload the image with a variable delay: 500ms, 1000ms, 1500ms, 2000ms, etc.
     setTimeout(ZSSEditor.reloadImage, nCall * 500, image, imageNode, imageNodeIdentifier, remoteImageId, nCall);
 }
-
-/**
- *  @brief      Update the progress indicator for the image identified with the value in progress.
- *
- *  @param      imageNodeIdentifier This is a unique ID provided by the caller.
- *  @param      progress    A value between 0 and 1 indicating the progress on the image.
- */
-ZSSEditor.setProgressOnImage = function(imageNodeIdentifier, progress) {
-    var imageNode = this.getImageNodeWithIdentifier(imageNodeIdentifier);
-    var imageProgressNode = this.getImageProgressNodeWithIdentifier(imageNodeIdentifier);
-
-    if (imageNode.length == 0 || imageProgressNode.length == 0){
-        return;
-    }
-
-    if (progress == 0) {
-        imageNode.addClass("uploading");
-    }
-
-    // Revert to non-compatibility image container once image upload has begun. This centers the overlays on the image
-    // (instead of the screen), while still circumventing the small container bug the compat class was added to fix
-    if (progress > 0) {
-        this.getImageContainerNodeWithIdentifier(imageNodeIdentifier).removeClass("compat");
-    }
-
-    imageProgressNode.attr("value",progress);
-};
 
 /**
  *  @brief      Notifies that the image upload as finished
@@ -1454,7 +1472,7 @@ ZSSEditor.insertLocalVideo = function(videoNodeIdentifier, posterURL) {
 
     ZSSEditor.trackNodeForMutation(this.getVideoContainerNodeWithIdentifier(videoNodeIdentifier));
 
-    this.setProgressOnVideo(videoNodeIdentifier, 0);
+    this.setProgressOnMedia(videoNodeIdentifier, 0);
 
     this.sendEnabledStyles();
 };
@@ -1518,34 +1536,6 @@ ZSSEditor.replaceLocalVideoWithRemoteVideo = function(videoNodeIdentifier, remot
     // it to be ignored by the webview because of the previous callback being done.
     var thisObj = this;
     setTimeout(function() { thisObj.sendVideoReplacedCallback(videoNodeIdentifier);}, 500);
-};
-
-/**
- *  @brief      Update the progress indicator for the Video identified with the value in progress.
- *
- *  @param      VideoNodeIdentifier This is a unique ID provided by the caller.
- *  @param      progress    A value between 0 and 1 indicating the progress on the Video.
- */
-ZSSEditor.setProgressOnVideo = function(videoNodeIdentifier, progress) {
-    var videoNode = this.getVideoNodeWithIdentifier(videoNodeIdentifier);
-    var videoProgressNode = this.getVideoProgressNodeWithIdentifier(videoNodeIdentifier);
-
-    if (videoNode.length == 0 || videoProgressNode.length == 0){
-        return;
-    }
-
-    if (progress == 0) {
-        videoNode.addClass("uploading");
-    }
-
-    // Revert to non-compatibility video container once video upload has begun. This centers the overlays on the
-    // placeholder image (instead of the screen), while still circumventing the small container bug the compat class
-    // was added to fix
-    if (progress > 0) {
-        this.getVideoContainerNodeWithIdentifier(videoNodeIdentifier).removeClass("compat");
-    }
-
-    videoProgressNode.attr("value",progress);
 };
 
 /**

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1370,6 +1370,7 @@ ZSSEditor.markImageUploadFailed = function(imageNodeIdentifier, message) {
     var imageProgressNode = this.getImageProgressNodeWithIdentifier(imageNodeIdentifier);
     if (imageProgressNode.length != 0){
         imageProgressNode.addClass('failed');
+        imageProgressNode.attr("value", 0);
     }
 
     // Delete the compatibility overlay if present
@@ -1630,6 +1631,7 @@ ZSSEditor.markVideoUploadFailed = function(videoNodeIdentifier, message) {
     var videoProgressNode = this.getVideoProgressNodeWithIdentifier(videoNodeIdentifier);
     if (videoProgressNode.length != 0){
         videoProgressNode.addClass('failed');
+        videoProgressNode.attr("value", 0);
     }
 
     // Delete the compatibility overlay if present

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1059,6 +1059,11 @@ ZSSEditor.sendOptimisticProgressUpdate = function(mediaNodeIdentifier, nCall) {
 
     var mediaNode = ZSSEditor.getMediaNodeWithIdentifier(mediaNodeIdentifier);
 
+    // Don't send progress updates to failed media
+    if (mediaNode.length != 0 && mediaNode[0].classList.contains("failed")) {
+        return;
+    }
+
     ZSSEditor.setProgressOnMedia(mediaNodeIdentifier, nCall / 100);
     ZSSEditor.setupOptimisticProgressUpdate(mediaNodeIdentifier, nCall + 1);
 };

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1037,6 +1037,13 @@ ZSSEditor.setProgressOnMedia = function(mediaNodeIdentifier, progress) {
         this.getMediaContainerNodeWithIdentifier(mediaNodeIdentifier).removeClass("compat");
     }
 
+    // Sometimes the progress bar can be stuck at 100% for a long time while further processing happens
+    // From a UX perspective, it's better to just keep the progress bars at 90% until the upload is really complete
+    // and the progress bar is removed entirely
+    if (progress > 0.9) {
+        return;
+    }
+
     mediaProgressNode.attr("value", progress);
 };
 

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1400,6 +1400,8 @@ ZSSEditor.unmarkImageUploadFailed = function(imageNodeIdentifier) {
 
     // Display the compatibility overlay again if present
     imageContainerNode.find("span.upload-overlay").removeClass("failed");
+
+    this.setProgressOnMedia(imageNodeIdentifier, 0);
 };
 
 /**
@@ -1658,6 +1660,8 @@ ZSSEditor.unmarkVideoUploadFailed = function(videoNodeIdentifier) {
 
     // Display the compatibility overlay again if present
     videoContainerNode.find("span.upload-overlay").removeClass("failed");
+
+    this.setProgressOnMedia(videoNodeIdentifier, 0);
 };
 
 /**

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1408,6 +1408,10 @@ ZSSEditor.unmarkImageUploadFailed = function(imageNodeIdentifier) {
     imageContainerNode.find("span.upload-overlay").removeClass("failed");
 
     this.setProgressOnMedia(imageNodeIdentifier, 0);
+
+    if (nativeState.androidApiLevel > 18) {
+        setTimeout(ZSSEditor.setupOptimisticProgressUpdate, 300, imageNodeIdentifier, 1);
+    }
 };
 
 /**
@@ -1669,6 +1673,10 @@ ZSSEditor.unmarkVideoUploadFailed = function(videoNodeIdentifier) {
     videoContainerNode.find("span.upload-overlay").removeClass("failed");
 
     this.setProgressOnMedia(videoNodeIdentifier, 0);
+
+    if (nativeState.androidApiLevel > 18) {
+        setTimeout(ZSSEditor.setupOptimisticProgressUpdate, 300, videoNodeIdentifier, 1);
+    }
 };
 
 /**

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1023,7 +1023,8 @@ ZSSEditor.setProgressOnMedia = function(mediaNodeIdentifier, progress) {
     var mediaNode = this.getMediaNodeWithIdentifier(mediaNodeIdentifier);
     var mediaProgressNode = this.getMediaProgressNodeWithIdentifier(mediaNodeIdentifier);
 
-    if (mediaNode.length == 0 || mediaProgressNode.length == 0){
+    // Don't allow the progress bar to move backward
+    if (mediaNode.length == 0 || mediaProgressNode.length == 0 || mediaProgressNode.attr("value") > progress) {
         return;
     }
 
@@ -1045,6 +1046,21 @@ ZSSEditor.setProgressOnMedia = function(mediaNodeIdentifier, progress) {
     }
 
     mediaProgressNode.attr("value", progress);
+};
+
+ZSSEditor.setupOptimisticProgressUpdate = function(mediaNodeIdentifier, nCall) {
+    setTimeout(ZSSEditor.sendOptimisticProgressUpdate, nCall * 100, mediaNodeIdentifier, nCall);
+};
+
+ZSSEditor.sendOptimisticProgressUpdate = function(mediaNodeIdentifier, nCall) {
+    if (nCall > 15) {
+        return;
+    }
+
+    var mediaNode = ZSSEditor.getMediaNodeWithIdentifier(mediaNodeIdentifier);
+
+    ZSSEditor.setProgressOnMedia(mediaNodeIdentifier, nCall / 100);
+    ZSSEditor.setupOptimisticProgressUpdate(mediaNodeIdentifier, nCall + 1);
 };
 
 ZSSEditor.sendMediaRemovedCallback = function(mediaNodeIdentifier) {
@@ -1175,6 +1191,10 @@ ZSSEditor.insertLocalImage = function(imageNodeIdentifier, localImageUrl) {
     ZSSEditor.trackNodeForMutation(this.getImageContainerNodeWithIdentifier(imageNodeIdentifier));
 
     this.setProgressOnMedia(imageNodeIdentifier, 0);
+
+    if (nativeState.androidApiLevel > 18) {
+        setTimeout(ZSSEditor.setupOptimisticProgressUpdate, 300, imageNodeIdentifier, 1);
+    }
 
     this.sendEnabledStyles();
 };
@@ -1480,6 +1500,10 @@ ZSSEditor.insertLocalVideo = function(videoNodeIdentifier, posterURL) {
     ZSSEditor.trackNodeForMutation(this.getVideoContainerNodeWithIdentifier(videoNodeIdentifier));
 
     this.setProgressOnMedia(videoNodeIdentifier, 0);
+
+    if (nativeState.androidApiLevel > 18) {
+        setTimeout(ZSSEditor.setupOptimisticProgressUpdate, 300, videoNodeIdentifier, 1);
+    }
 
     this.sendEnabledStyles();
 };


### PR DESCRIPTION
Addresses #290. Adds 'optimistic' upload progress support for media uploads.

The progress bar will gradually increment to 15%, increasingly slowly, until it either stops at 15% (and waits for the real upload progress to catch up) or is overtaken before then by the real upload progress.

This PR also limits the displayed progress to 90%. This prevent situations where the progress shows full but there is still processing going on, and the upload appears to have bugged out. Now, the progress bar will remain at 90% until the upload is really complete and the local media url is replaced with the uploaded url.

cc @maxme
