### PR TITLE
Fix #347: Fix content loss on slower/older devices

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -517,21 +517,38 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
             String selectedText = mSourceViewContent.getText().toString().substring(mSelectionStart, mSelectionEnd);
             dialogBundle.putString(LinkDialogFragment.LINK_DIALOG_ARG_TEXT, selectedText);
+
+            linkDialogFragment.setArguments(dialogBundle);
+            linkDialogFragment.show(getFragmentManager(), LinkDialogFragment.class.getSimpleName());
         } else {
             // Visual mode
-            mGetSelectedTextCountDownLatch = new CountDownLatch(1);
-            mWebView.execJavaScriptFromString("ZSSEditor.execFunctionForResult('getSelectedTextToLinkify');");
-            try {
-                if (mGetSelectedTextCountDownLatch.await(1, TimeUnit.SECONDS)) {
-                    dialogBundle.putString(LinkDialogFragment.LINK_DIALOG_ARG_TEXT, mJavaScriptResult);
-                }
-            } catch (InterruptedException e) {
-                AppLog.d(T.EDITOR, "Failed to obtain selected text from JS editor.");
-            }
-        }
+            Thread thread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    mGetSelectedTextCountDownLatch = new CountDownLatch(1);
+                    getActivity().runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            mWebView.execJavaScriptFromString(
+                                    "ZSSEditor.execFunctionForResult('getSelectedTextToLinkify');");
+                        }
+                    });
 
-        linkDialogFragment.setArguments(dialogBundle);
-        linkDialogFragment.show(getFragmentManager(), LinkDialogFragment.class.getSimpleName());
+                    try {
+                        if (mGetSelectedTextCountDownLatch.await(1, TimeUnit.SECONDS)) {
+                            dialogBundle.putString(LinkDialogFragment.LINK_DIALOG_ARG_TEXT, mJavaScriptResult);
+                        }
+                    } catch (InterruptedException e) {
+                        AppLog.d(T.EDITOR, "Failed to obtain selected text from JS editor.");
+                    }
+
+                    linkDialogFragment.setArguments(dialogBundle);
+                    linkDialogFragment.show(getFragmentManager(), LinkDialogFragment.class.getSimpleName());
+                }
+            });
+
+            thread.start();
+        }
     }
 
     @Override

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -448,21 +448,39 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         updateFormatBarEnabledState(true);
 
         if (toggleButton.isChecked()) {
-            mSourceViewTitle.setText(getTitle());
+            Thread thread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    // Update mTitle and mContentHtml with the latest state from the ZSSEditor
+                    getTitle();
+                    getContent();
 
-            SpannableString spannableContent = new SpannableString(getContent());
-            HtmlStyleUtils.styleHtmlForDisplay(spannableContent);
-            mSourceViewContent.setText(spannableContent);
+                    getActivity().runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            // Set HTML mode state
+                            mSourceViewTitle.setText(mTitle);
 
-            mWebView.setVisibility(View.GONE);
-            mSourceView.setVisibility(View.VISIBLE);
+                            SpannableString spannableContent = new SpannableString(mContentHtml);
+                            HtmlStyleUtils.styleHtmlForDisplay(spannableContent);
+                            mSourceViewContent.setText(spannableContent);
 
-            mSourceViewContent.requestFocus();
-            mSourceViewContent.setSelection(0);
+                            mWebView.setVisibility(View.GONE);
+                            mSourceView.setVisibility(View.VISIBLE);
 
-            InputMethodManager imm = ((InputMethodManager) getActivity()
-                    .getSystemService(Context.INPUT_METHOD_SERVICE));
-            imm.showSoftInput(mSourceViewContent, InputMethodManager.SHOW_IMPLICIT);
+                            mSourceViewContent.requestFocus();
+                            mSourceViewContent.setSelection(0);
+
+                            InputMethodManager imm = ((InputMethodManager) getActivity()
+                                    .getSystemService(Context.INPUT_METHOD_SERVICE));
+                            imm.showSoftInput(mSourceViewContent, InputMethodManager.SHOW_IMPLICIT);
+                        }
+                    });
+                }
+            });
+
+            thread.start();
+
         } else {
             mWebView.setVisibility(View.VISIBLE);
             mSourceView.setVisibility(View.GONE);


### PR DESCRIPTION
Fixes #347 and #309.

There was a race condition problem in the way we were retrieving content from the ZSSEditor. `ZSSEditor.execFunctionForResult()` executes successfully, but the request never reaches the ZSSEditor until the UI thread is unblocked (when the `CountDownLatch` wait times out). I'm not entirely sure why this is happening, as the JS runs on its own thread, but this is likely due to some older `WebView` internals. The issue consistently occurred on the (very slow) API16 Nexus S and with some frequency on emulators of various API levels.

I solved the issue by moving `CountDownLatch`-reliant processes to worker threads, with the worker thread responsible for updating the UI when the JS requests return.
