### PR TITLE
Issue #230: First character appears as zero-width space

### DIFF
--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -556,12 +556,6 @@ ZSSEditor.getYCaretInfo = function() {
     return this.caretInfo;
 };
 
-// MARK: - Default paragraph separator
-
-ZSSEditor.defaultParagraphSeparatorTag = function() {
-    return '<' + this.defaultParagraphSeparator + '>';
-};
-
 // MARK: - Styles
 
 ZSSEditor.setBold = function() {
@@ -684,9 +678,9 @@ ZSSEditor.setHeading = function(heading) {
 	var formatBlock = document.queryCommandValue('formatBlock');
 
 	if (formatBlock.length > 0 && formatBlock.toLowerCase() == formatTag) {
-		document.execCommand('formatBlock', false, this.defaultParagraphSeparatorTag());
+		document.execCommand('formatBlock', false, Util.buildOpeningTag(this.defaultParagraphSeparator));
 	} else {
-		document.execCommand('formatBlock', false, '<' + formatTag + '>');
+		document.execCommand('formatBlock', false, Util.buildOpeningTag(formatTag));
 	}
 
 	ZSSEditor.sendEnabledStyles();
@@ -697,9 +691,9 @@ ZSSEditor.setParagraph = function() {
 	var formatBlock = document.queryCommandValue('formatBlock');
 
 	if (formatBlock.length > 0 && formatBlock.toLowerCase() == formatTag) {
-		document.execCommand('formatBlock', false, this.defaultParagraphSeparatorTag());
+		document.execCommand('formatBlock', false, Util.buildOpeningTag(this.defaultParagraphSeparator));
 	} else {
-		document.execCommand('formatBlock', false, '<' + formatTag + '>');
+		document.execCommand('formatBlock', false, Util.buildOpeningTag(formatTag));
 	}
 
 	ZSSEditor.sendEnabledStyles();
@@ -792,8 +786,8 @@ ZSSEditor.setBackgroundColor = function(color) {
  */
 ZSSEditor.insertHTMLWrappedInParagraphTags = function(html) {
     var space = '<br>';
-    var paragraphOpenTag = '<' + this.defaultParagraphSeparator + '>';
-    var paragraphCloseTag = '</' + this.defaultParagraphSeparator + '>';
+    var paragraphOpenTag = Util.buildOpeningTag(this.defaultParagraphSeparator);
+    var paragraphCloseTag = Util.buildClosingTag(this.defaultParagraphSeparator);
 
     if (this.getFocusedField().getHTML().length == 0) {
         html = paragraphOpenTag + html;
@@ -818,7 +812,7 @@ ZSSEditor.insertLink = function(url, title) {
     var html = '<a href="' + url + '">' + title + "</a>";
 
     if (this.getFocusedField().getHTML().length == 0) {
-        html = '<' + this.defaultParagraphSeparator + '>' + html;
+        html = Util.buildOpeningTag(this.defaultParagraphSeparator) + html;
     }
 
     this.insertHTML(html);

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3080,6 +3080,15 @@ ZSSField.prototype.handleKeyDownEvent = function(e) {
     } else if (wasEnterPressed && !this.isMultiline()) {
         e.preventDefault();
     } else if (this.isMultiline()) {
+        // For hardware keyboards, don't do any paragraph handling for non-printable keyCodes
+        // This avoids the filler zero-width space character from being inserted and displayed in the content field
+        // when special keys are pressed in new posts
+        var wasTabPressed = (e.keyCode == '9');
+        var intKeyCode = parseInt(e.keyCode, 10);
+        if (wasTabPressed || (intKeyCode > 13 && intKeyCode < 46)) {
+            return;
+        }
+
         this.wrapCaretInParagraphIfNecessary();
 
         if (wasEnterPressed) {

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3077,11 +3077,12 @@ ZSSField.prototype.handleKeyDownEvent = function(e) {
         e.preventDefault();
     } else if (this.isMultiline()) {
         // For hardware keyboards, don't do any paragraph handling for non-printable keyCodes
+        // https://css-tricks.com/snippets/javascript/javascript-keycodes/
         // This avoids the filler zero-width space character from being inserted and displayed in the content field
         // when special keys are pressed in new posts
         var wasTabPressed = (e.keyCode == '9');
         var intKeyCode = parseInt(e.keyCode, 10);
-        if (wasTabPressed || (intKeyCode > 13 && intKeyCode < 46)) {
+        if (wasTabPressed || (intKeyCode > 13 && intKeyCode < 46) || intKeyCode == 192) {
             return;
         }
 

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3101,7 +3101,7 @@ ZSSField.prototype.handleKeyDownEvent = function(e) {
             var currentHtml = this.getWrappedDomNode().innerHTML;
             if (currentHtml.search('<' + ZSSEditor.defaultParagraphSeparator) == -1) {
                 ZSSEditor.focusedField.setHTML(Util.wrapHTMLInTag(currentHtml, ZSSEditor.defaultParagraphSeparator));
-                ZSSEditor.resetSelectionOnField('zss_field_content', 1);
+                ZSSEditor.resetSelectionOnField(this.getWrappedDomNode().id, 1);
             }
 
             var sel = window.getSelection();

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -634,7 +634,7 @@ ZSSEditor.setUnderline = function() {
 /**
  *  @brief      Turns blockquote ON or OFF for the current selection.
  *  @details    This method makes sure that the contents of the blockquotes are surrounded by the
- *              defaultParagraphSeparatorTag (by default '<p>').  This ensures parity with the web
+ *              defaultParagraphSeparator tag (by default '<p>').  This ensures parity with the web
  *              editor.
  */
 ZSSEditor.setBlockquote = function() {

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -2781,7 +2781,7 @@ ZSSEditor.joinAdjacentSiblingsBlockquotes = function(node) {
 ZSSEditor.joinAdjacentSiblingsOrAncestorBlockquotes = function(node) {
 
     var currentNode = node;
-    var rootNode = this.getFocusedField().wrappedDomNode();
+    var rootNode = this.getFocusedField().getWrappedDomNode();
     var joined = false;
 
     while (currentNode
@@ -3004,7 +3004,7 @@ function ZSSField(wrappedObject) {
     this.multiline = false;
     this.wrappedObject = wrappedObject;
 
-    if (this.wrappedDomNode().hasAttribute('nostyle')) {
+    if (this.getWrappedDomNode().hasAttribute('nostyle')) {
         this.hasNoStyle = true;
     }
 
@@ -3363,7 +3363,7 @@ ZSSField.prototype.disableEditing = function () {
 ZSSField.prototype.wrapCaretInParagraphIfNecessary = function()
 {
     var closerParentNode = ZSSEditor.closerParentNode();
-    var parentNodeShouldBeParagraph = (closerParentNode == this.wrappedDomNode()
+    var parentNodeShouldBeParagraph = (closerParentNode == this.getWrappedDomNode()
                                        || closerParentNode.nodeName == NodeName.BLOCKQUOTE);
 
     if (parentNodeShouldBeParagraph) {
@@ -3464,6 +3464,6 @@ ZSSField.prototype.setPlaceholderText = function(placeholder) {
 
 // MARK: - Wrapped Object
 
-ZSSField.prototype.wrappedDomNode = function() {
+ZSSField.prototype.getWrappedDomNode = function() {
     return this.wrappedObject[0];
 };

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -386,12 +386,14 @@ ZSSEditor.restoreRange = function(){
     }
 };
 
-ZSSEditor.resetSelectionOnField = function(fieldId) {
+ZSSEditor.resetSelectionOnField = function(fieldId, offset) {
+    offset = typeof offset !== 'undefined' ? offset : 0;
+
     var query = "div#" + fieldId;
     var field = document.querySelector(query);
     var range = document.createRange();
-    range.setStart(field, 0);
-    range.setEnd(field, 0);
+    range.setStart(field, offset);
+    range.setEnd(field, offset);
 
     var selection = document.getSelection();
     selection.removeAllRanges();

--- a/libs/editor-common/assets/android-editor.html
+++ b/libs/editor-common/assets/android-editor.html
@@ -13,6 +13,7 @@
     <script src="underscore-min.js"></script>
     <script src="shortcode.js"></script>
     <script src="jquery.mobile-events.min.js"></script>
+    <script src="editor-utils.js"></script>
     <script src="ZSSRichTextEditor.js"></script>
     <script src="wpload.js"></script>
     <script src="wpsave.js"></script>

--- a/libs/editor-common/assets/editor-utils.js
+++ b/libs/editor-common/assets/editor-utils.js
@@ -8,6 +8,6 @@ Util.buildClosingTag = function(tagName) {
     return '</' + tagName + '>';
 };
 
-Util.wrapHtmlInTag = function(html, tagName) {
+Util.wrapHTMLInTag = function(html, tagName) {
     return Util.buildOpeningTag(tagName) + html + Util.buildClosingTag(tagName);
 };

--- a/libs/editor-common/assets/editor-utils.js
+++ b/libs/editor-common/assets/editor-utils.js
@@ -1,0 +1,13 @@
+function Util () {}
+
+Util.buildOpeningTag = function(tagName) {
+    return '<' + tagName + '>';
+};
+
+Util.buildClosingTag = function(tagName) {
+    return '</' + tagName + '>';
+};
+
+Util.wrapHtmlInTag = function(html, tagName) {
+    return Util.buildOpeningTag(tagName) + html + Util.buildClosingTag(tagName);
+};


### PR DESCRIPTION
Fixes #230.

There are two separate bugs fixed by this PR. They are both caused by our use of the `&#x200b;` character (zero-width space) when we add a new paragraph. We rely on this to force the cursor to move inside the `<div></div>` tag we add. It was previously possible to avoid using it when `p` was the paragraph separator, but since we changed that to `div` in order to work around the backspace autocorrect bug (https://github.com/wordpress-mobile/WordPress-Editor-Android/pull/334), it's no longer possible. The WebView seems to be stricter about `div` tags than `p` tags for some reason.

<h4>1. Hardware keyboard non-printable keycodes</h4>


On hardware keyboards at all API levels, entering non-printable keycodes (tab, ctrl, shift, etc.) were still triggering the paragraph insertion code. When a normal key is entered, it instantaneously replaces the filler `&#x200b;` space with the character entered and nothing odd is visible to the user. Non-printable keycodes, however, just caused the space character to be entered, and it would stay there until a printable key was pressed to replace it.

We're now ignoring non-printable characters from hardware keyboards in the new paragraph handling code, so that paragraphs aren't added until a real character is entered.

<h4>2. API19 doesn't like zero-width space in new paragraphs</h4>


On an `API19` software keyboard, the first character pressed is always replaced by the `&#x200b;` literal. If the user keeps typing it will go away, but they will lose the first character they entered. I'm not sure why this is happening, but it's a WebView issue that was introduced at version `37` and fixed by version `39`. This means that it affects all `API19` devices, and also `API21` devices running the default, never updated Android System WebView.

The fix for this was to stop wrapping the first text entered in paragraph tags on `API19`, and instead correct it when the user enters a new line. This isn't ideal, but so far I haven't found any side effects (or a better solution). All the same, I've limited the change to `API19` only to avoid possibly breaking things for other API levels that didn't even need this fix.

I've considered extending the fix to `API21` as well. Unless a device's OEM has disabled the standalone Android System WebView app, any `API21` device that has updated their WebView app since ~early 2015 should not have the bug anymore. I've tried to discover if there are any OEMs who have done this; Samsung (usually the worst case scenario for WebView customization by OEM) at least hasn't, or at least not on the S6.

Instead, we'll [track](https://github.com/wordpress-mobile/WordPress-Android/issues/3978) the WebView version in our analytics, so we can look for users running version `<39` of the Android System WebView on `API21` and extend the fix accordingly.

Note that stock `API22` ships with `v39`, which doesn't exhibit this bug.

cc @maxme
