### PR TITLE
Issue/350 fix newlines api16

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebViewAbstract.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebViewAbstract.java
@@ -28,6 +28,7 @@ import org.wordpress.android.util.UrlUtils;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -60,7 +61,8 @@ public abstract class EditorWebViewAbstract extends WebView {
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
                 if (url != null && url.startsWith("callback") && mJsCallbackReceiver != null) {
-                    String[] split = url.split(":", 2);
+                    String data = URLDecoder.decode(url);
+                    String[] split = data.split(":", 2);
                     String callbackId = split[0];
                     String params = (split.length > 1 ? split[1] : "");
                     mJsCallbackReceiver.executeCallback(callbackId, params);

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3448,7 +3448,8 @@ ZSSField.prototype.getHTMLForCallback = function() {
     } else {
         var html;
         if (nativeState.androidApiLevel < 17) {
-            // URI Encode HTML on API < 17 because of the use of WebViewClient.shouldOverrideUrlLoading
+            // URI Encode HTML on API < 17 because of the use of WebViewClient.shouldOverrideUrlLoading. Data must
+            // be decoded in shouldOverrideUrlLoading.
             html = encodeURIComponent(this.getHTML());
         } else {
             html = this.getHTML();

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3446,9 +3446,15 @@ ZSSField.prototype.getHTMLForCallback = function() {
     if (this.hasNoStyle) {
         contentsArgument = "contents=" + this.strippedHTML();
     } else {
-        contentsArgument = "contents=" + this.getHTML();
+        var html;
+        if (nativeState.androidApiLevel < 17) {
+            // URI Encode HTML on API < 17 because of the use of WebViewClient.shouldOverrideUrlLoading
+            html = encodeURIComponent(this.getHTML());
+        } else {
+            html = this.getHTML();
+        }
+        contentsArgument = "contents=" + html;
     }
-
     var joinedArguments = functionArgument + defaultCallbackSeparator + idArgument + defaultCallbackSeparator +
         contentsArgument;
     ZSSEditor.callback('callback-response-string', joinedArguments);


### PR DESCRIPTION
Due to the introduction of the pseudo-callback receiver `WebViewClient.shouldOverrideUrlLoading` in this PR  https://github.com/wordpress-mobile/WordPress-Editor-Android/pull/289 for API < 17. We had an issue with HTML, that was somehow encoded and stripped. Using encoderURI before calling the callback and decodeURI when receiving the data ensure the string data won't be automatically changed/stripped.

This PR should only affect API <= 16
