### PR TITLE
Issue #344: Unable to backspace to remove blockquotes

### DIFF
--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3305,6 +3305,13 @@ ZSSField.prototype.afterKeyDownEvent = function(e) {
         newRange.setEnd(newFocusEle, 1);
         selection.removeAllRanges();
         selection.addRange(newRange);
+    } else if (focusedNode.nodeName == NodeName.DIV && focusedNode.parentNode.nodeName == NodeName.BLOCKQUOTE
+        && focusedNode.parentNode.childNodes.length == 1
+        && (focusedNode.innerHTML.length == 0 || focusedNode.innerHTML == '<br>')) {
+        // When a post begins with a blockquote, and there's content after that blockquote, backspacing inside that
+        // blockquote will work until the blockquote is empty. After that, backspace will have no effect
+        // This fix identifies that situation and makes the call to setBlockquote() to toggle off the blockquote
+        ZSSEditor.setBlockquote();
     }
 };
 

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3292,9 +3292,7 @@ ZSSField.prototype.handlePasteEvent = function(e) {
  *  @brief      Fires after 'keydown' events, when the field contents have already been modified
  */
 ZSSField.prototype.afterKeyDownEvent = function(beforeHTML, e) {
-    if (beforeHTML == e.target.innerHTML) {
-        return;
-    }
+    var htmlWasModified = (beforeHTML != e.target.innerHTML);
 
     var selection = document.getSelection();
     var range = selection.getRangeAt(0).cloneRange();
@@ -3305,6 +3303,12 @@ ZSSField.prototype.afterKeyDownEvent = function(beforeHTML, e) {
 
     // Blockquote handling
     if (focusedNode.nodeName == NodeName.BLOCKQUOTE && focusedNodeIsEmpty) {
+        if (!htmlWasModified) {
+            // We only want to handle this if the last character inside a blockquote was just deleted - if the HTML
+            // is unchanged, it might be that afterKeyDownEvent was called too soon, and we should avoid doing anything
+            return;
+        }
+
         // When using backspace to delete the contents of a blockquote, the div within the blockquote is deleted
         // This makes the blockquote unable to be deleted using backspace, and also causes autocorrect issues on API19+
         range.startContainer.innerHTML = Util.wrapHTMLInTag('<br>', ZSSEditor.defaultParagraphSeparator);

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -387,13 +387,18 @@ ZSSEditor.restoreRange = function(){
 };
 
 ZSSEditor.resetSelectionOnField = function(fieldId, offset) {
-    offset = typeof offset !== 'undefined' ? offset : 0;
-
     var query = "div#" + fieldId;
     var field = document.querySelector(query);
+
+    this.giveFocusToElement(field, offset);
+};
+
+ZSSEditor.giveFocusToElement = function(element, offset) {
+    offset = typeof offset !== 'undefined' ? offset : 0;
+
     var range = document.createRange();
-    range.setStart(field, offset);
-    range.setEnd(field, offset);
+    range.setStart(element, offset);
+    range.setEnd(element, offset);
 
     var selection = document.getSelection();
     selection.removeAllRanges();
@@ -3299,12 +3304,8 @@ ZSSField.prototype.afterKeyDownEvent = function(e) {
         range.startContainer.innerHTML = '<div><br></div>';
 
         // Give focus to new div
-        var newFocusEle = focusedNode.firstChild;
-        var newRange = document.createRange();
-        newRange.setStart(newFocusEle, 1);
-        newRange.setEnd(newFocusEle, 1);
-        selection.removeAllRanges();
-        selection.addRange(newRange);
+        var newFocusElement = focusedNode.firstChild;
+        ZSSEditor.giveFocusToElement(newFocusElement, 1);
     } else if (focusedNode.nodeName == NodeName.DIV && focusedNode.parentNode.nodeName == NodeName.BLOCKQUOTE
         && focusedNode.parentNode.childNodes.length == 1
         && (focusedNode.innerHTML.length == 0 || focusedNode.innerHTML == '<br>')) {

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3087,7 +3087,7 @@ ZSSField.prototype.handleKeyDownEvent = function(e) {
     var wasEnterPressed = (e.keyCode == '13');
 
     // Handle keyDownEvent actions that need to happen after the event has completed (and the field has been modified)
-    setTimeout(this.afterKeyDownEvent, 20, e);
+    setTimeout(this.afterKeyDownEvent, 20, e.target.innerHTML, e);
 
     if (this.isComposing) {
         e.stopPropagation();
@@ -3291,7 +3291,11 @@ ZSSField.prototype.handlePasteEvent = function(e) {
 /**
  *  @brief      Fires after 'keydown' events, when the field contents have already been modified
  */
-ZSSField.prototype.afterKeyDownEvent = function(e) {
+ZSSField.prototype.afterKeyDownEvent = function(beforeHTML, e) {
+    if (beforeHTML == e.target.innerHTML) {
+        return;
+    }
+
     var selection = document.getSelection();
     var range = selection.getRangeAt(0).cloneRange();
     var focusedNode = range.startContainer;

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3317,7 +3317,8 @@ ZSSField.prototype.afterKeyDownEvent = function(beforeHTML, e) {
         var newFocusElement = focusedNode.firstChild;
         ZSSEditor.giveFocusToElement(newFocusElement, 1);
     } else if (focusedNode.nodeName == NodeName.DIV && focusedNode.parentNode.nodeName == NodeName.BLOCKQUOTE
-        && focusedNode.parentNode.childNodes.length == 1 && focusedNodeIsEmpty) {
+        && focusedNode.parentNode.previousSibling == null && focusedNode.parentNode.childNodes.length == 1
+        && focusedNodeIsEmpty) {
         // When a post begins with a blockquote, and there's content after that blockquote, backspacing inside that
         // blockquote will work until the blockquote is empty. After that, backspace will have no effect
         // This fix identifies that situation and makes the call to setBlockquote() to toggle off the blockquote

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3296,19 +3296,20 @@ ZSSField.prototype.afterKeyDownEvent = function(e) {
     var range = selection.getRangeAt(0).cloneRange();
     var focusedNode = range.startContainer;
 
+    var focusedNodeIsEmpty = (focusedNode.innerHTML != undefined
+        && (focusedNode.innerHTML.length == 0 || focusedNode.innerHTML == '<br>'));
+
     // Blockquote handling
-    if (focusedNode.nodeName == NodeName.BLOCKQUOTE
-        && (focusedNode.innerHTML.length == 0 || focusedNode.innerHTML == '<br>')) {
+    if (focusedNode.nodeName == NodeName.BLOCKQUOTE && focusedNodeIsEmpty) {
         // When using backspace to delete the contents of a blockquote, the div within the blockquote is deleted
         // This makes the blockquote unable to be deleted using backspace, and also causes autocorrect issues on API19+
-        range.startContainer.innerHTML = '<div><br></div>';
+        range.startContainer.innerHTML = Util.wrapHTMLInTag('<br>', ZSSEditor.defaultParagraphSeparator);
 
         // Give focus to new div
         var newFocusElement = focusedNode.firstChild;
         ZSSEditor.giveFocusToElement(newFocusElement, 1);
     } else if (focusedNode.nodeName == NodeName.DIV && focusedNode.parentNode.nodeName == NodeName.BLOCKQUOTE
-        && focusedNode.parentNode.childNodes.length == 1
-        && (focusedNode.innerHTML.length == 0 || focusedNode.innerHTML == '<br>')) {
+        && focusedNode.parentNode.childNodes.length == 1 && focusedNodeIsEmpty) {
         // When a post begins with a blockquote, and there's content after that blockquote, backspacing inside that
         // blockquote will work until the blockquote is empty. After that, backspace will have no effect
         // This fix identifies that situation and makes the call to setBlockquote() to toggle off the blockquote


### PR DESCRIPTION
Fixes #344.

Backspacing the entire contents of a blockquote was clearing the `div` tags inside it, causing backspace to be unable to delete it (WebView shenanigans). This also meant that when typing content back in, we would sometimes end up with bad autocorrect bugs.

The 'usual' way of inserting `&#x200b;` characters to force the div tag to stay open didn't work for blockquotes.

The only fix I found was to add a 'afterTextChanged' feature, which is fired with a delay whenever input is detected. This seemed to work okay, even on API16, but just in case I added a check to avoid running the method if the HTML hasn't actually been modified (which might mean `afterKeyDownEvent` was called too soon): https://github.com/wordpress-mobile/WordPress-Editor-Android/commit/2206af5203a43a70288c2ebff9bcf68900714338

cc @maxme 
