### PR TITLE
Issue #361: Media missing 'uploading' class on API<19

### DIFF
--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1037,13 +1037,13 @@ ZSSEditor.setProgressOnMedia = function(mediaNodeIdentifier, progress) {
     var mediaNode = this.getMediaNodeWithIdentifier(mediaNodeIdentifier);
     var mediaProgressNode = this.getMediaProgressNodeWithIdentifier(mediaNodeIdentifier);
 
+    if (progress == 0) {
+        mediaNode.addClass("uploading");
+    }
+
     // Don't allow the progress bar to move backward
     if (mediaNode.length == 0 || mediaProgressNode.length == 0 || mediaProgressNode.attr("value") > progress) {
         return;
-    }
-
-    if (progress == 0) {
-        mediaNode.addClass("uploading");
     }
 
     // Revert to non-compatibility image container once image upload has begun. This centers the overlays on the image


### PR DESCRIPTION
Fixes #361. While working on [optimistic upload progress](https://github.com/wordpress-mobile/WordPress-Editor-Android/pull/343), I introduced a bug where the `uploading` class wasn't added to uploading media on older APIs, because [this line](https://github.com/wordpress-mobile/WordPress-Editor-Android/compare/issue/361-old-api-upload-css?expand=1#diff-cfce53bcfd107d0762d2395366d54762R1045) exited too soon (since the progress element isn't supported by those API levels). Without the `uploading` class, [this css](https://github.com/wordpress-mobile/WordPress-Editor-Android/pull/270/commits/7b26aa70e9e14374f04d341b8f4104364dc64e95) wasn't applied.

cc @maxme
