### PR TITLE
Issue #345: Buggy links inside blockquotes

### DIFF
--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -818,12 +818,16 @@ ZSSEditor.insertHTMLWrappedInParagraphTags = function(html) {
     this.insertHTML(paragraphOpenTag + space + paragraphCloseTag);
 };
 
-// Needs addClass method
-
 ZSSEditor.insertLink = function(url, title) {
     var html = '<a href="' + url + '">' + title + "</a>";
 
-    if (this.getFocusedField().getHTML().length == 0) {
+    var parentBlockQuoteNode = ZSSEditor.closerParentNodeWithName('blockquote');
+
+    if (this.getFocusedField().getHTML().length == 0 || parentBlockQuoteNode) {
+        // Wrap the link tag in paragraph tags when the post is empty, and also when inside a blockquote
+        // The latter is to fix a bug with document.execCommand('insertHTML') inside a blockquote, where the div inside
+        // the blockquote is ignored and the link tag is inserted outside it, on a new line with no wrapping div
+        // Wrapping the link in paragraph tags makes insertHTML join it to the existing div, for some reason
         html = Util.buildOpeningTag(this.defaultParagraphSeparator) + html;
     }
 

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -827,11 +827,16 @@ ZSSEditor.insertLink = function(url, title) {
     var currentNode = currentRange.startContainer;
     var currentNodeIsEmpty = (currentNode.innerHTML == '' || currentNode.innerHTML == '<br>');
 
-    if (this.getFocusedField().getHTML().length == 0 || (parentBlockQuoteNode && !currentNodeIsEmpty)) {
+    var selectionIsAtStartOrEnd = Util.rangeIsAtStartOfParent(currentRange) || Util.rangeIsAtEndOfParent(currentRange);
+
+    if (this.getFocusedField().getHTML().length == 0
+        || (parentBlockQuoteNode && !currentNodeIsEmpty && selectionIsAtStartOrEnd)) {
         // Wrap the link tag in paragraph tags when the post is empty, and also when inside a blockquote
         // The latter is to fix a bug with document.execCommand('insertHTML') inside a blockquote, where the div inside
         // the blockquote is ignored and the link tag is inserted outside it, on a new line with no wrapping div
         // Wrapping the link in paragraph tags makes insertHTML join it to the existing div, for some reason
+        // We exclude being on an empty line inside a blockquote and when the selection isn't at the beginning or end
+        // of the line, as the fix is unnecessary in both those cases and causes paragraph formatting issues
         html = Util.buildOpeningTag(this.defaultParagraphSeparator) + html;
     }
 

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -823,7 +823,11 @@ ZSSEditor.insertLink = function(url, title) {
 
     var parentBlockQuoteNode = ZSSEditor.closerParentNodeWithName('blockquote');
 
-    if (this.getFocusedField().getHTML().length == 0 || parentBlockQuoteNode) {
+    var currentRange = document.getSelection().getRangeAt(0);
+    var currentNode = currentRange.startContainer;
+    var currentNodeIsEmpty = (currentNode.innerHTML == '' || currentNode.innerHTML == '<br>');
+
+    if (this.getFocusedField().getHTML().length == 0 || (parentBlockQuoteNode && !currentNodeIsEmpty)) {
         // Wrap the link tag in paragraph tags when the post is empty, and also when inside a blockquote
         // The latter is to fix a bug with document.execCommand('insertHTML') inside a blockquote, where the div inside
         // the blockquote is ignored and the link tag is inserted outside it, on a new line with no wrapping div

--- a/libs/editor-common/assets/editor-utils.js
+++ b/libs/editor-common/assets/editor-utils.js
@@ -1,5 +1,7 @@
 function Util () {}
 
+/* Tag building */
+
 Util.buildOpeningTag = function(tagName) {
     return '<' + tagName + '>';
 };
@@ -10,4 +12,14 @@ Util.buildClosingTag = function(tagName) {
 
 Util.wrapHTMLInTag = function(html, tagName) {
     return Util.buildOpeningTag(tagName) + html + Util.buildClosingTag(tagName);
+};
+
+/* Selection */
+
+Util.rangeIsAtStartOfParent = function(range) {
+    return (range.startContainer.previousSibling == null && range.startOffset == 0);
+};
+
+Util.rangeIsAtEndOfParent = function(range) {
+    return (range.startContainer.nextSibling == null && range.endOffset == range.endContainer.length);
 };

--- a/libs/editor-common/assets/editor-utils.js
+++ b/libs/editor-common/assets/editor-utils.js
@@ -21,5 +21,6 @@ Util.rangeIsAtStartOfParent = function(range) {
 };
 
 Util.rangeIsAtEndOfParent = function(range) {
-    return (range.startContainer.nextSibling == null && range.endOffset == range.endContainer.length);
+    return ((range.startContainer.nextSibling == null || range.startContainer.nextSibling == "<br>")
+        && range.endOffset == range.endContainer.length);
 };


### PR DESCRIPTION
Fixes #345. The cause was weird WebView behavior when calling `execCommand('insertHTML')` to insert the link tag: instead of being inserted within the current `div`, it was added outside of it.

So instead of:

``` HTML
<blockquote>
  <div>text <a href="http://example">link</a></div>
</blockquote>
```

we had:

``` HTML
<blockquote>
  <div>text </div>
  <a href="http://example">link</a>
</blockquote>
```

This also caused autocorrect issues, as usually happens when adding text anywhere but inside a `div`.

The fix was to wrap links in `div` tags inside blockquotes, but I had to exclude a few cases: empty newline inside blockquote, and inserting a link in the middle of a line (with text surrounding on both sides). Those were cases where the `div` wrapping is unnecessary, and causes other issues if used (double-wrapping in `div`s, or toggling `div` off on the entire line).

cc @maxme 
