### PR TITLE
Issue #227: Buggy paragraph formatting when exiting lists

### DIFF
--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -2606,8 +2606,24 @@ ZSSEditor.completeListEditing = function() {
             if (node.nodeType == 1 &&
                     (node.tagName.toUpperCase() == NodeName.UL
                         || node.tagName.toUpperCase() == NodeName.OL)) {
-                // Make a new P node as a sibling to the parent node
-                document.execCommand('insertParagraph', false);
+
+                var focusedNode = document.getSelection().getRangeAt(0).startContainer;
+
+                if (focusedNode.nodeType == 3) {
+                    // If the focused node is a text node, the list item was not empty when toggled off
+                    // Wrap the text in a div and attach it as a sibling to the div wrapping the list
+                    var parentParagraph = focusedNode.parentNode;
+                    var paragraph = document.createElement('div');
+
+                    paragraph.appendChild(focusedNode);
+                    parentParagraph.insertAdjacentElement('afterEnd', paragraph);
+
+                    ZSSEditor.giveFocusToElement(paragraph, 1);
+                } else {
+                    // Attach a new paragraph node as a sibling to the parent node
+                    document.execCommand('insertParagraph', false);
+                }
+
                 // Remove any superfluous <br> tags that are created
                 ZSSEditor.scrubBRFromNode(node.parentNode);
                 break;

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -2579,7 +2579,7 @@ ZSSEditor.previousNode = function(node) {
         return node;
     }
     var parent = node.parentNode;
-    if (parent && parent.nodeType.hasChildNodes()) {
+    if (parent && parent.hasChildNodes()) {
         return parent;
     }
     return null;


### PR DESCRIPTION
Fixes #227. The ultimate cause of the bug was that exiting a list by toggling off the list button didn't wrap the resulting text in paragraph tags. This caused blockquote wrapping to include the list above it, and also led to autocorrect issues.

Specifically, starting with (as shown in the video in the issue):

``` HTML
<div>
  <ol>
    <li>Item 1</li>
    <li>Item 2</li>
  </ol>
</div>
```

Pressing the list button with the cursor on Item 2 resulted in:

``` HTML
<div>
  <ol>
    <li>Item 1</li>
  </ol>
</div>
Item 2
```

With this fix, we now get:

``` HTML
<div>
  <ol>
    <li>Item 1</li>
  </ol>
</div>
<div>
  Item 2
</div>
```

And blockquote wrapping after that works correctly (only wraps 'Item 2').

cc @maxme
