### PR TITLE
Issue #365: IndexSizeError when inserting links in empty posts

### DIFF
--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -411,29 +411,31 @@ ZSSEditor.getSelectedText = function() {
 };
 
 ZSSEditor.canExpandBackward = function(range) {
-  var caretRange = range.cloneRange();
-  if (range.startOffset == 0) {
-  	return false;
-  }
-  caretRange.setStart(range.startContainer, range.startOffset - 1);
-  caretRange.setEnd(range.startContainer, range.startOffset);
-  if (!caretRange.toString().match(/\w/)) {
-  	return false;
-  }
-  return true;
+    var caretRange = range.cloneRange();
+    if (range.startOffset == 0) {
+    return false;
+    }
+    caretRange.setStart(range.startContainer, range.startOffset - 1);
+    caretRange.setEnd(range.startContainer, range.startOffset);
+    if (!caretRange.toString().match(/\w/)) {
+    return false;
+    }
+    return true;
 };
 
 ZSSEditor.canExpandForward = function(range) {
-  var caretRange = range.cloneRange();
-  if (range.endOffset == range.endContainer.length)  {
-  	return false;
-  }
-  caretRange.setStart(range.endContainer, range.endOffset);
-  caretRange.setEnd(range.endContainer, range.endOffset + 1);
-  if (!caretRange.toString().match(/\w/)) {
-  	return false;
-  }
-  return true;
+    var caretRange = range.cloneRange();
+    if (range.endOffset == range.endContainer.length)  {
+    return false;
+    }
+    caretRange.setStart(range.endContainer, range.endOffset);
+    if (range.endOffset )
+    caretRange.setEnd(range.endContainer, range.endOffset + 1);
+    var strin = caretRange.toString();
+    if (!caretRange.toString().match(/\w/)) {
+    return false;
+    }
+    return true;
 };
 
 ZSSEditor.getSelectedTextToLinkify = function() {

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -411,6 +411,10 @@ ZSSEditor.getSelectedText = function() {
 };
 
 ZSSEditor.canExpandBackward = function(range) {
+    // Can't expand if focus is not a text node
+    if (!range.endContainer.nodeType == 3) {
+        return false;
+    }
     var caretRange = range.cloneRange();
     if (range.startOffset == 0) {
     return false;
@@ -424,6 +428,10 @@ ZSSEditor.canExpandBackward = function(range) {
 };
 
 ZSSEditor.canExpandForward = function(range) {
+    // Can't expand if focus is not a text node
+    if (!range.endContainer.nodeType == 3) {
+        return false;
+    }
     var caretRange = range.cloneRange();
     if (range.endOffset == range.endContainer.length)  {
     return false;


### PR DESCRIPTION
Fixes #365. The error was because `ZSSEditor.canExpandBackward`/`canExpandForward` is being passed a `div` node, rather than the text node it expects, when the post is empty. Returning `false` automatically avoids the index out of bounds error.

cc @maxme
