### PR TITLE
fix #376: escape quotes in imageMeta var

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -677,7 +677,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 return;
             }
 
-            final String imageMeta = extras.getString("imageMeta");
+            final String imageMeta = Utils.escapeQuotes(StringUtils.notNullStr(extras.getString("imageMeta")));
             final int imageRemoteId = extras.getInt("imageRemoteId");
             final boolean isFeaturedImage = extras.getBoolean("isFeatured");
 


### PR DESCRIPTION
fix #376: escape quotes in imageMeta var
