### PR TITLE
fix #368: remove a workaround that introduced the issue

### DIFF
--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3256,14 +3256,8 @@ ZSSField.prototype.handleTapEvent = function(e) {
         if (targetNode.nodeName.toLowerCase() == 'a') {
             var arguments = ['url=' + encodeURIComponent(targetNode.href),
                              'title=' + encodeURIComponent(targetNode.innerHTML)];
-
             var joinedArguments = arguments.join(defaultCallbackSeparator);
-
-            var thisObj = this;
-
-            // WORKAROUND: force the event to become sort of "after-tap" through setTimeout()
-            //
-            setTimeout(function() { thisObj.callback('callback-link-tap', joinedArguments);}, 500);
+            this.callback('callback-link-tap', joinedArguments);
         }
 
         if (targetNode.nodeName.toLowerCase() == 'img') {


### PR DESCRIPTION
Problem comes from the 500ms delay [here](https://github.com/wordpress-mobile/WordPress-Editor-Android/blob/develop/libs/editor-common/assets/ZSSRichTextEditor.js#L3264-L3266). I'm not sure to understand why there is a workaround here. Does `after-tap` mean `tap up` event?

Looking at `git blame`, I guess that was used in iOS. When I remove the delay, everything seems to work as expected.
