### PR TITLE
Issue #373: Don't scroll to the current cursor position when tapping an image

### DIFF
--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -417,6 +417,19 @@ ZSSEditor.giveFocusToElement = function(element, offset) {
     selection.addRange(range);
 };
 
+ZSSEditor.setFocusAfterElement = function(element) {
+    var selection = window.getSelection();
+
+    if (selection.rangeCount) {
+        var range = document.createRange();
+
+        range.setStartAfter(element);
+        range.setEndAfter(element);
+        selection.removeAllRanges();
+        selection.addRange(range);
+    }
+};
+
 ZSSEditor.getSelectedText = function() {
 	var selection = window.getSelection();
 	return selection.toString();
@@ -3263,7 +3276,7 @@ ZSSField.prototype.handleTapEvent = function(e) {
         if (targetNode.nodeName.toLowerCase() == 'img') {
             // If the image is uploading, or is a local image do not select it.
             if ( targetNode.dataset.wpid || targetNode.dataset.video_wpid ) {
-                this.sendImageTappedCallback( targetNode );
+                this.sendImageTappedCallback(targetNode);
                 return;
             }
 
@@ -3275,22 +3288,22 @@ ZSSField.prototype.handleTapEvent = function(e) {
 
             // Is the tapped image the image we're editing?
             if ( targetNode == ZSSEditor.currentEditingImage ) {
-                ZSSEditor.removeImageSelectionFormatting( targetNode );
-                this.sendImageTappedCallback( targetNode );
+                ZSSEditor.removeImageSelectionFormatting(targetNode);
+                this.sendImageTappedCallback(targetNode);
                 return;
             }
 
             // If there is a selected image, deselect it. A different image was tapped.
             if ( ZSSEditor.currentEditingImage ) {
-                ZSSEditor.removeImageSelectionFormatting( ZSSEditor.currentEditingImage );
+                ZSSEditor.removeImageSelectionFormatting(ZSSEditor.currentEditingImage);
             }
 
             // Format and flag the image as selected.
             ZSSEditor.currentEditingImage = targetNode;
-            ZSSEditor.applyImageSelectionFormatting( targetNode );
+            ZSSEditor.applyImageSelectionFormatting(targetNode);
 
+            ZSSEditor.setFocusAfterElement(targetNode);
 
-            ZSSEditor.giveFocusToElement(targetNode, 0);
             return;
         }
 

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3289,6 +3289,8 @@ ZSSField.prototype.handleTapEvent = function(e) {
             ZSSEditor.currentEditingImage = targetNode;
             ZSSEditor.applyImageSelectionFormatting( targetNode );
 
+
+            ZSSEditor.giveFocusToElement(targetNode, 0);
             return;
         }
 


### PR DESCRIPTION
Fixes #373.

When an image was tapped with the keyboard down, the screen would scroll to the current cursor position as the keyboard came up, which could be very far from the image that was actually tapped.

With this patch, the cursor is moved to the image, so the screen only scrolls to the bottom of the image that was tapped when the keyboard comes up.

cc @maxme 
