### PR TITLE
Issue #389: Autocorrect sometimes breaks paragraphs at start of posts

### DIFF
--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3164,6 +3164,7 @@ ZSSField.prototype.handleFocusEvent = function(e) {
 ZSSField.prototype.handleKeyDownEvent = function(e) {
 
     var wasEnterPressed = (e.keyCode == '13');
+    var isHardwareKeyboardPaste = (e.ctrlKey && e.keyCode == '86');
 
     // Handle keyDownEvent actions that need to happen after the event has completed (and the field has been modified)
     setTimeout(this.afterKeyDownEvent, 20, e.target.innerHTML, e);
@@ -3196,18 +3197,30 @@ ZSSField.prototype.handleKeyDownEvent = function(e) {
         // incorrectly, so we skip it in this case.
         //
         // 3. On all APIs, hardware pasting (CTRL + V) doesn't automatically wrap the paste in paragraph tags in
-        // new posts. ZSSField.handlePasteEvent() does not address this problem. It's the same fix as #2 above, but we
-        // have to extend the `containsParagraphSeparators` check to all APIs, not just API19 and below, to fix
-        // hardware pasting.
+        // new posts. ZSSField.handlePasteEvent() won't fix the wrapping for hardware pastes if
+        // wrapCaretInParagraphIfNecessary() goes through first, so we need to skip it in that case.
+        // For API < 19, this is fixed implicitly by the 'containsParagraphSeparators' check, but for newer APIs we
+        // specifically detect hardware keyboard pastes and skip paragraph wrapping in that case
+        // case skip calling wrapCaretInParagraphIfNecessary().
+        //
+        // Previously, the check was 'if (containsParagraphSeparators)' for all API levels, but this turns out to cause
+        // an autocorrect issue for new posts on API 23+:
+        // https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/389
+        // That issue can be fixed by allowing wrapCaretInParagraphIfNecessary() to go through when adding text to an
+        // empty post on those API levels, as long as we exclude the special case of hardware keyboard pasting
+        //
+        // We're using 'nativeState.androidApiLevel>19' rather than >22 because, even though the bug only appears on
+        // 23+ at the time of writing, it's entirely possible a future System WebView or Keyboard update will introduce
+        // the bug on 21+.
         var containsParagraphSeparators = this.getWrappedDomNode().innerHTML.search(
                 '<' + ZSSEditor.defaultParagraphSeparator) > -1;
-        if (containsParagraphSeparators) {
+        if (containsParagraphSeparators || (nativeState.androidApiLevel > 19 && !isHardwareKeyboardPaste)) {
             this.wrapCaretInParagraphIfNecessary();
         }
 
         if (wasEnterPressed) {
             // Wrap the existing text in paragraph tags if necessary (this should only be needed if
-            // wrapCaretInParagraphIfNecessary() was skipped earlier (API19))
+            // wrapCaretInParagraphIfNecessary() was skipped earlier)
             var currentHtml = this.getWrappedDomNode().innerHTML;
             if (currentHtml.search('<' + ZSSEditor.defaultParagraphSeparator) == -1) {
                 ZSSEditor.focusedField.setHTML(Util.wrapHTMLInTag(currentHtml, ZSSEditor.defaultParagraphSeparator));


### PR DESCRIPTION
Fixes #389.

It turns out to be fixable by allowing [wrapCaretInParagraphIfNecessary()](https://github.com/wordpress-mobile/WordPress-Editor-Android/blob/2bd069c75c269db66231c2445489fee8341f7864/libs/editor-common/assets/ZSSRichTextEditor.js#L3218) to go through for newer API levels (`23+` to fix the bug, but `21+` for safety). This is basically reverting https://github.com/wordpress-mobile/WordPress-Editor-Android/pull/358/commits/f16e2220172f96571cc35f619eb50491ced9ee03, and using a different method for detecting and ignoring hardware keyboard pastes (to keep the original fix working).

cc @maxme
