### PR TITLE
Issue #401: Blockquote toggle off issues in new posts

### DIFF
--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -688,6 +688,7 @@ ZSSEditor.setBlockquote = function() {
     var selection = document.getSelection();
     var range = selection.getRangeAt(0).cloneRange();
     var sendStyles = false;
+    var doEmptyFieldCleanup = false;
 
     // Make sure text being wrapped in blockquotes is inside paragraph tags
     // (should be <blockquote><paragraph>contents</paragraph></blockquote>)
@@ -710,6 +711,7 @@ ZSSEditor.setBlockquote = function() {
         var nextChildNode = childNodes[childNodes.length-1].nextSibling;
         if (nextChildNode && nextChildNode.nodeName == NodeName.DIV && nextChildNode.innerHTML == "") {
             childNodes.push(nextChildNode);
+            doEmptyFieldCleanup = true;
         }
 
         if (childNodes && childNodes.length) {
@@ -718,6 +720,12 @@ ZSSEditor.setBlockquote = function() {
     }
 
     rangy.restoreSelection(savedSelection);
+
+    // When turning off an empty blockquote in an empty post, ensure there aren't any leftover empty paragraph tags
+    // https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/401
+    if (doEmptyFieldCleanup) {
+        ZSSEditor.focusedField.emptyFieldIfNoContents();
+    }
 
     if (sendStyles) {
         ZSSEditor.sendEnabledStyles();

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -703,6 +703,15 @@ ZSSEditor.setBlockquote = function() {
 
         var childNodes = this.getChildNodesIntersectingRange(ancestorElement, range);
 
+        // On older APIs, the rangy selection node is targeted when turning off empty blockquotes at the start of a post
+        // In that case, add the empty DIV element next to the rangy selection to the childNodes array to correctly
+        // turn the blockquote off
+        // https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/401
+        var nextChildNode = childNodes[childNodes.length-1].nextSibling;
+        if (nextChildNode && nextChildNode.nodeName == NodeName.DIV && nextChildNode.innerHTML == "") {
+            childNodes.push(nextChildNode);
+        }
+
         if (childNodes && childNodes.length) {
             this.toggleBlockquoteForSpecificChildNodes(ancestorElement, childNodes);
         }

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -688,7 +688,6 @@ ZSSEditor.setBlockquote = function() {
     var selection = document.getSelection();
     var range = selection.getRangeAt(0).cloneRange();
     var sendStyles = false;
-    var doEmptyFieldCleanup = false;
 
     // Make sure text being wrapped in blockquotes is inside paragraph tags
     // (should be <blockquote><paragraph>contents</paragraph></blockquote>)
@@ -711,7 +710,6 @@ ZSSEditor.setBlockquote = function() {
         var nextChildNode = childNodes[childNodes.length-1].nextSibling;
         if (nextChildNode && nextChildNode.nodeName == NodeName.DIV && nextChildNode.innerHTML == "") {
             childNodes.push(nextChildNode);
-            doEmptyFieldCleanup = true;
         }
 
         if (childNodes && childNodes.length) {
@@ -723,7 +721,8 @@ ZSSEditor.setBlockquote = function() {
 
     // When turning off an empty blockquote in an empty post, ensure there aren't any leftover empty paragraph tags
     // https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/401
-    if (doEmptyFieldCleanup) {
+    var currentContenteditableDiv = ZSSEditor.focusedField.getWrappedDomNode();
+    if (currentContenteditableDiv.children.length == 1 && currentContenteditableDiv.firstChild.innerHTML == "") {
         ZSSEditor.focusedField.emptyFieldIfNoContents();
     }
 


### PR DESCRIPTION
Fixes #401, correcting the behavior when toggling off an empty blockquote when the post is otherwise empty.

To test, launch editor with empty post and toggle blockquote on and then off again without typing anything.
1. On API19 and below, toggling the blockquote off now actually works, removing the empty blockquote
2. On all API levels, toggling the blockquote off no longer leaves an empty newline behind, so that now the placeholder shows up again right away

cc @maxme
