### PR TITLE
Escape invisible unicode separator characters in HTML mode

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/Utils.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/Utils.java
@@ -61,6 +61,11 @@ public class Utils {
             html = html.replace("'", "\\'");
             html = html.replace("\r", "\\r");
             html = html.replace("\n", "\\n");
+
+            // Escape invisible line separator (U+2028) and paragraph separator (U+2029) characters
+            // https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/405
+            html = html.replace("\u2028", "\\u2028");
+            html = html.replace("\u2029", "\\u2029");
         }
         return html;
     }


### PR DESCRIPTION
Fixes #405.

To test, copy and paste each of the following lines into the editor (there are invisible separators, `U+2028` between the two 'Line' words, and `U+2029` between the two 'Paragraph' words):

```
Line Line

Paragraph Paragraph
```

Next, switch to HTML mode and back. Without this patch, any changes made during HTML mode won't be preserved, and there should be a console error when switching back to visual from HTML mode:

```
E/WordPress-EDITOR: Uncaught SyntaxError: Unexpected token ILLEGAL -- From line 1 of 
```

With this patch, there should be no error and changes made in HTML mode should be preserved.

cc @maxme 
