### PR TITLE
Issue #377: Video remove button

### DIFF
--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1658,6 +1658,12 @@ ZSSEditor.replaceLocalVideoWithRemoteVideo = function(videoNodeIdentifier, remot
         containerNode.replaceWith(videoNode);
     }
 
+    // Wrap video in edit-container node for a permanent delete button overlay
+    var containerHtml = '<span class="edit-container"><span class="delete-overlay" contenteditable="false"></span></span>';
+    videoNode.insertAdjacentHTML('beforebegin', containerHtml);
+    var selectionNode = videoNode.previousSibling;
+    selectionNode.appendChild(videoNode);
+
     var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
     ZSSEditor.callback("callback-input", joinedArguments);
     // We invoke the sendVideoReplacedCallback with a delay to avoid for

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1549,12 +1549,18 @@ ZSSEditor.insertVideo = function(videoURL, posterURL, videopressID) {
 
     html += '></video>';
 
-    this.insertHTMLWrappedInParagraphTags(html);
+    this.insertHTMLWrappedInParagraphTags('&#x200b;' + html);
 
     // Wrap video in edit-container node for a permanent delete button overlay
     var videoNode = $('video[id=' + videoId + ']')[0];
-    this.applyEditContainer(videoNode);
+    var selectionNode = this.applyEditContainer(videoNode);
     videoNode.removeAttribute('id');
+
+    // Remove the zero-width space node (it's not needed now that the paragraph-wrapped video is in place)
+    var zeroWidthNode = selectionNode.previousSibling;
+    if (zeroWidthNode != null && zeroWidthNode.nodeType == 3) {
+        zeroWidthNode.parentNode.removeChild(zeroWidthNode);
+    }
 
     this.sendEnabledStyles();
     this.callback("callback-action-finished");

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1830,6 +1830,13 @@ ZSSEditor.replaceVideosForShortcode = function ( html) {
     return str;
 }
 
+ZSSEditor.removeVideoContainers = function(html) {
+    var containerRegex = /<span class="edit-container">(?:<span class="delete-overlay"[^<>]*><\/span>)?(\[[^<>]*)<\/span>/g;
+    var str = html.replace(containerRegex, ZSSEditor.removeVideoContainerCallback);
+
+    return str;
+}
+
 ZSSEditor.removeVideoPressVisualFormattingCallback = function( match, content ) {
     return "[wpvideo " + content + "]";
 }
@@ -1860,6 +1867,10 @@ ZSSEditor.removeVideoVisualFormattingCallback = function( match, content ) {
     var shortcode = videoElement.outerHTML.replace(/</g, "[");
     shortcode = shortcode.replace(/>/g, "]");
     return shortcode;
+}
+
+ZSSEditor.removeVideoContainerCallback = function( match, content ) {
+    return content;
 }
 
 ZSSEditor.applyVideoPressFormattingCallback = function( match ) {
@@ -2519,6 +2530,7 @@ ZSSEditor.removeVisualFormatting = function( html ) {
     str = ZSSEditor.removeCaptionFormatting( str );
     str = ZSSEditor.replaceVideoPressVideosForShortcode( str );
     str = ZSSEditor.replaceVideosForShortcode( str );
+    str = ZSSEditor.removeVideoContainers( str );
 
     // More tag
     str = str.replace(/<hr class="more-tag" wp-more-data="(.*?)">/igm, "<!--more$1-->")

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1562,6 +1562,8 @@ ZSSEditor.insertVideo = function(videoURL, posterURL, videopressID) {
         zeroWidthNode.parentNode.removeChild(zeroWidthNode);
     }
 
+    ZSSEditor.trackNodeForMutation($(selectionNode));
+
     this.sendEnabledStyles();
     this.callback("callback-action-finished");
 };
@@ -1671,6 +1673,8 @@ ZSSEditor.replaceLocalVideoWithRemoteVideo = function(videoNodeIdentifier, remot
     }
 
     this.applyEditContainer(videoNode);
+
+    ZSSEditor.trackNodeForMutation($(selectionNode));
 
     var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
     ZSSEditor.callback("callback-input", joinedArguments);

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1806,7 +1806,7 @@ ZSSEditor.removeVideo = function(videoNodeIdentifier) {
  *  @brief      Wrap the video in an edit-container with a delete button overlay.
  */
 ZSSEditor.applyEditContainer = function(videoNode) {
-    var containerHtml = '<span class="edit-container"><span class="delete-overlay" contenteditable="false"></span></span>';
+    var containerHtml = '<span class="edit-container" contenteditable="false"><span class="delete-overlay"></span></span>';
     videoNode.insertAdjacentHTML('beforebegin', containerHtml);
 
     var selectionNode = videoNode.previousSibling;
@@ -1831,7 +1831,7 @@ ZSSEditor.replaceVideosForShortcode = function ( html) {
 }
 
 ZSSEditor.removeVideoContainers = function(html) {
-    var containerRegex = /<span class="edit-container">(?:<span class="delete-overlay"[^<>]*><\/span>)?(\[[^<>]*)<\/span>/g;
+    var containerRegex = /<span class="edit-container" contenteditable="false">(?:<span class="delete-overlay"[^<>]*><\/span>)?(\[[^<>]*)<\/span>/g;
     var str = html.replace(containerRegex, ZSSEditor.removeVideoContainerCallback);
 
     return str;
@@ -1885,7 +1885,7 @@ ZSSEditor.applyVideoPressFormattingCallback = function( match ) {
            + posterSVG +' onclick="" onerror="ZSSEditor.sendVideoPressInfoRequest(\'' + videopressID +'\');"></video>';
 
     // Wrap video in edit-container node for a permanent delete button overlay
-    var containerStart = '<span class="edit-container"><span class="delete-overlay" contenteditable="false"></span>';
+    var containerStart = '<span class="edit-container" contenteditable="false"><span class="delete-overlay"></span>';
     out = containerStart + out + '</span><br>';
 
     return out;
@@ -1925,7 +1925,7 @@ ZSSEditor.applyVideoFormattingCallback = function( match ) {
     out += ' onclick="" controls="controls"></video>';
 
     // Wrap video in edit-container node for a permanent delete button overlay
-    var containerStart = '<span class="edit-container"><span class="delete-overlay" contenteditable="false"></span>';
+    var containerStart = '<span class="edit-container" contenteditable="false"><span class="delete-overlay"></span>';
     out = containerStart + out + '</span><br>';
 
     return out;

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1536,7 +1536,8 @@ ZSSEditor.removeAllFailedMediaUploads = function() {
  *
  */
 ZSSEditor.insertVideo = function(videoURL, posterURL, videopressID) {
-    var html = '<video webkit-playsinline src="' + videoURL + '" onclick="" controls="controls" preload="metadata"';
+    var videoId = Date.now();
+    var html = '<video id=' + videoId + ' webkit-playsinline src="' + videoURL + '" onclick="" controls="controls" preload="metadata"';
 
     if (posterURL != '') {
         html += ' poster="' + posterURL + '"';
@@ -1549,6 +1550,11 @@ ZSSEditor.insertVideo = function(videoURL, posterURL, videopressID) {
     html += '></video>';
 
     this.insertHTMLWrappedInParagraphTags(html);
+
+    // Wrap video in edit-container node for a permanent delete button overlay
+    var videoNode = $('video[id=' + videoId + ']')[0];
+    this.applyEditContainer(videoNode);
+    videoNode.removeAttribute('id');
 
     this.sendEnabledStyles();
     this.callback("callback-action-finished");
@@ -1658,11 +1664,7 @@ ZSSEditor.replaceLocalVideoWithRemoteVideo = function(videoNodeIdentifier, remot
         containerNode.replaceWith(videoNode);
     }
 
-    // Wrap video in edit-container node for a permanent delete button overlay
-    var containerHtml = '<span class="edit-container"><span class="delete-overlay" contenteditable="false"></span></span>';
-    videoNode.insertAdjacentHTML('beforebegin', containerHtml);
-    var selectionNode = videoNode.previousSibling;
-    selectionNode.appendChild(videoNode);
+    this.applyEditContainer(videoNode);
 
     var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
     ZSSEditor.callback("callback-input", joinedArguments);
@@ -1789,6 +1791,19 @@ ZSSEditor.removeVideo = function(videoNodeIdentifier) {
         videoContainerNode.remove();
     }
 };
+
+/**
+ *  @brief      Wrap the video in an edit-container with a delete button overlay.
+ */
+ZSSEditor.applyEditContainer = function(videoNode) {
+    var containerHtml = '<span class="edit-container"><span class="delete-overlay" contenteditable="false"></span></span>';
+    videoNode.insertAdjacentHTML('beforebegin', containerHtml);
+
+    var selectionNode = videoNode.previousSibling;
+    selectionNode.appendChild(videoNode);
+
+    return selectionNode;
+}
 
 ZSSEditor.replaceVideoPressVideosForShortcode = function ( html) {
     // call methods to restore any transformed content from its visual presentation to its source code.

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1672,7 +1672,7 @@ ZSSEditor.replaceLocalVideoWithRemoteVideo = function(videoNodeIdentifier, remot
         containerNode.replaceWith(videoNode);
     }
 
-    this.applyEditContainer(videoNode);
+    var selectionNode = this.applyEditContainer(videoNode);
 
     ZSSEditor.trackNodeForMutation($(selectionNode));
 

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -2545,19 +2545,21 @@ ZSSEditor.sendEnabledStyles = function(e) {
         // Find all relevant parent tags
         var parentTags = ZSSEditor.parentTags();
 
-        for (var i = 0; i < parentTags.length; i++) {
-            var currentNode = parentTags[i];
+        if (parentTags != null) {
+            for (var i = 0; i < parentTags.length; i++) {
+                var currentNode = parentTags[i];
 
-            if (currentNode.nodeName.toLowerCase() == 'a') {
-                ZSSEditor.currentEditingLink = currentNode;
+                if (currentNode.nodeName.toLowerCase() == 'a') {
+                    ZSSEditor.currentEditingLink = currentNode;
 
-                var title = encodeURIComponent(currentNode.text);
-                var href = encodeURIComponent(currentNode.href);
+                    var title = encodeURIComponent(currentNode.text);
+                    var href = encodeURIComponent(currentNode.href);
 
-                items.push('link-title:' + title);
-                items.push('link:' + href);
-            } else if (currentNode.nodeName == NodeName.BLOCKQUOTE) {
-                items.push('blockquote');
+                    items.push('link-title:' + title);
+                    items.push('link:' + href);
+                } else if (currentNode.nodeName == NodeName.BLOCKQUOTE) {
+                    items.push('blockquote');
+                }
             }
         }
 

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3819,6 +3819,12 @@ ZSSField.prototype.setHTML = function(html) {
     }
 
     this.wrappedObject.html(mutatedHTML);
+
+    // Track video container nodes for mutation
+    var videoNodes = $('span.edit-container > video');
+    for (var i = 0; i < videoNodes.length; i++) {
+        ZSSEditor.trackNodeForMutation($(videoNodes[i].parentNode));
+    }
 };
 
 // MARK: - Placeholder

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1884,7 +1884,10 @@ ZSSEditor.applyVideoPressFormattingCallback = function( match ) {
     var out = '<video data-wpvideopress="' + videopressID + '" webkit-playsinline src="" preload="metadata" poster='
            + posterSVG +' onclick="" onerror="ZSSEditor.sendVideoPressInfoRequest(\'' + videopressID +'\');"></video>';
 
-    out = out + '<br>';
+    // Wrap video in edit-container node for a permanent delete button overlay
+    var containerStart = '<span class="edit-container"><span class="delete-overlay" contenteditable="false"></span>';
+    out = containerStart + out + '</span><br>';
+
     return out;
 }
 
@@ -1919,7 +1922,11 @@ ZSSEditor.applyVideoFormattingCallback = function( match ) {
         out += ' preload="metadata"';
     }
 
-    out += ' onclick="" controls="controls"></video><br>';
+    out += ' onclick="" controls="controls"></video>';
+
+    // Wrap video in edit-container node for a permanent delete button overlay
+    var containerStart = '<span class="edit-container"><span class="delete-overlay" contenteditable="false"></span>';
+    out = containerStart + out + '</span><br>';
 
     return out;
 }

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1947,11 +1947,11 @@ ZSSEditor.setVideoPressLinks = function(videopressID, videoURL, posterURL ) {
         return;
     }
 
+    // It's safest to drop the onError now, to avoid endless calls if the video can't be loaded
+    // Even if sendVideoPressInfoRequest failed, it's still possible to request a reload by tapping the video
+    videoNode.attr('onError', '');
+
     if (videoURL.length == 0) {
-        // If no URL is being passed, the host activity probably doesn't have a record of this videopressID
-        // Drop the error event since it can cause an infinite loop in this case
-        // The user is still able to manually retry by tapping the video element
-        videoNode.attr('onError', '');
         return;
     }
 

--- a/libs/editor-common/assets/editor.css
+++ b/libs/editor-common/assets/editor.css
@@ -279,11 +279,8 @@ span.video_container.failed.smallFail::after {
     padding:1px;
 }
 
-
 .edit-container video {
-    -webkit-filter: blur(4px) grayscale(0.3);
-    margin:-1px; /*tiny margin to keep crisp edges when blurring the image*/
-    padding:1px;
+
 }
 
 /* default. use when images are > 100px w/h */


### PR DESCRIPTION
Fixes #377 and #408.

Adds a permanent span container to videos, with a delete button:

![377-video-delete-overlay](https://cloud.githubusercontent.com/assets/9613966/15987672/00d6a184-2fff-11e6-9495-cea95f943901.png)

This PR also fixes an issue reported by @tonyr59h, that adding remote videos to an empty post makes it difficult to tap under the video afterward. The problem was that the editor wasn't adding a newline after those videos, like it does for all images and for uploading videos.

The best way to test is to `subtree pull` this branch into WPAndroid, but it's also possible to check the remote video insertion code in isolation by calling [`ZSSEditor.insertVideo()`](https://github.com/wordpress-mobile/WordPress-Editor-Android/blob/531f3687115620564764e0c1a94f5875438cb151/libs/editor-common/assets/ZSSRichTextEditor.js#L1538) in the Chrome dev console with appropriate arguments.

There's a more general issue with paragraph formatting around media, which applies to all media and is due to the newline under media being stripped when switching to HTML mode and back, or opening an existing post. That's being tracked in #409.

Hopefully this also fixes all issues with #296 (needs testing on the Z5 and the HTC One now that `span`-wrapped videos are in the picture).

cc @maxme, and also @tonyr59h for a runthrough since he's the most talented at summoning video bugs
