### PR TITLE
Issue #411: Edit containers not being cleared when switching to HTML mode

### DIFF
--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1984,11 +1984,6 @@ ZSSEditor.applyImageSelectionFormatting = function( imageNode ) {
 }
 
 ZSSEditor.removeImageSelectionFormatting = function( imageNode ) {
-    if (!$('#zss_field_content')[0].contains(imageNode)) {
-        // The image node has already been removed from the document
-        return;
-    }
-
     var node = ZSSEditor.findImageCaptionNode( imageNode );
     if ( !node.parentNode || node.parentNode.className.indexOf( "edit-container" ) == -1 ) {
         return;
@@ -1996,9 +1991,12 @@ ZSSEditor.removeImageSelectionFormatting = function( imageNode ) {
 
     var parentNode = node.parentNode;
     var container = parentNode.parentNode;
-    container.insertBefore( node, parentNode );
-    // Use {node}.{parent}.removeChild() instead of {node}.remove(), since Android API<19 doesn't support Node.remove()
-    container.removeChild(parentNode);
+
+    if (container != null) {
+        container.insertBefore( node, parentNode );
+        // Use {node}.{parent}.removeChild() instead of {node}.remove(), since Android API<19 doesn't support Node.remove()
+        container.removeChild(parentNode);
+    }
 }
 
 ZSSEditor.removeImageSelectionFormattingFromHTML = function( html ) {


### PR DESCRIPTION
Fixes #411.

This bug was introduced fairly recently, in https://github.com/wordpress-mobile/WordPress-Android/pull/4157/commits/82903c73310d3af5e05cf74f2b583f10fde19cb6. That commit was fixing a crash report (https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/393), but it turns out that the null check will trip when switching to HTML mode and the edit container isn't cleared away. I changed the null check behavior so that #393 should still be fixed.

cc @maxme
