### PR TITLE
Add JavaScript unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ WordPress/src/main/res/values/com_crashlytics_export_strings.xml
 
 # libs
 libs/utils
+
+# Node-based JS Tests
+node_modules
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add new unit tests to `src/test/java/` and integration tests to `stc/androidTest
 
 ### JavaScript Tests ###
 
-This project also has functional tests for the JS part of the editor using [Mocha](https://mochajs.org/).
+This project also has unit tests for the JS part of the editor using [Mocha](https://mochajs.org/).
 
 To be able to run the tests, [npm](https://www.npmjs.com/) and Mocha (`npm install -g mocha`) are required.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ Integration testing is done with the [Android testing framework](http://develope
 
 Add new unit tests to `src/test/java/` and integration tests to `stc/androidTest/java/`.
 
+### JavaScript Tests ###
+
+This project also has functional tests for the JS part of the editor using [Mocha](https://mochajs.org/).
+
+To be able to run the tests, [npm](https://www.npmjs.com/) and Mocha (`npm install -g mocha`) are required.
+
+With npm and Mocha installed, from within `libs/editor-common/assets/test`, run:
+
+    npm install chai
+
+It should now be possible to run the tests using `mocha` inside `libs/editor-common/assets`.
+
 ## LICENSE ##
 
 WordPress-Editor-Android is an Open Source project covered by the [GNU General Public License version 2](LICENSE.md).

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3656,9 +3656,9 @@ ZSSField.prototype.isEmpty = function() {
 ZSSField.prototype.getHTML = function() {
     var html = this.wrappedObject.html();
     if (ZSSEditor.defaultParagraphSeparator == 'div') {
-        html = html.replace(/(<div(?=[>\s]))/igm, '<p').replace(/<\/div>/igm, '</p>');
+        html = Formatter.convertDivToP(html);
     }
-    html = wp.saveText(html);
+    html = Formatter.visualToHtml(html);
     html = ZSSEditor.removeVisualFormatting( html );
     return html;
 };

--- a/libs/editor-common/assets/android-editor.html
+++ b/libs/editor-common/assets/android-editor.html
@@ -14,6 +14,7 @@
     <script src="shortcode.js"></script>
     <script src="jquery.mobile-events.min.js"></script>
     <script src="editor-utils.js"></script>
+    <script src="editor-utils-formatter.js"></script>
     <script src="ZSSRichTextEditor.js"></script>
     <script src="wpload.js"></script>
     <script src="wpsave.js"></script>

--- a/libs/editor-common/assets/editor-utils-formatter.js
+++ b/libs/editor-common/assets/editor-utils-formatter.js
@@ -22,7 +22,6 @@ Formatter.convertPToDiv = function(html) {
     mutatedHTML = mutatedHTML.replace(/(<img [^<>]*>|<\/a>|<\/video>|<\/span>)<br \/>/igm,
             function replaceBrWithDivs(match) { return match.substr(0, match.length - 6) + '</div><div>'; });
 
-    // if document ends with media item and </div>, add <div><br></div>? to fix that last media issue
     return mutatedHTML;
 }
 

--- a/libs/editor-common/assets/editor-utils-formatter.js
+++ b/libs/editor-common/assets/editor-utils-formatter.js
@@ -142,3 +142,7 @@ Formatter.applyVideoFormattingCallback = function(match) {
 
     return out;
 }
+
+if (typeof module !== 'undefined' && module.exports != null) {
+    exports.Formatter = Formatter;
+}

--- a/libs/editor-common/assets/editor-utils-formatter.js
+++ b/libs/editor-common/assets/editor-utils-formatter.js
@@ -26,6 +26,15 @@ Formatter.convertPToDiv = function(html) {
     return mutatedHTML;
 }
 
+Formatter.visualToHtml = function(html) {
+    return wp.saveText(html);
+    return Formatter.removeVisualFormatting(mutatedHTML);
+}
+
+Formatter.convertDivToP = function(html) {
+    return html.replace(/(<div(?=[>\s]))/igm, '<p').replace(/<\/div>/igm, '</p>');
+}
+
 /**
  *  @brief      Applies editor specific visual formatting.
  *

--- a/libs/editor-common/assets/editor-utils-formatter.js
+++ b/libs/editor-common/assets/editor-utils-formatter.js
@@ -1,0 +1,135 @@
+function Formatter () {}
+
+// Video format tags supported by the [video] shortcode: https://codex.wordpress.org/Video_Shortcode
+// mp4, m4v and webm prioritized since they're supported by the stock player as of Android API 23
+Formatter.videoShortcodeFormats = ["mp4", "m4v", "webm", "ogv", "wmv", "flv"];
+
+Formatter.htmlToVisual = function(html) {
+    var mutatedHTML = wp.loadText(html);
+    return Formatter.applyVisualFormatting(mutatedHTML);
+}
+
+Formatter.convertPToDiv = function(html) {
+    // Replace the paragraph tags we get from wpload with divs
+    var mutatedHTML = html.replace(/(<p(?=[>\s]))/igm, '<div').replace(/<\/p>/igm, '</div>');
+
+    // Replace break tags around media items with paragraphs
+    // The break tags appear when text and media are separated by only a line break rather than a paragraph break,
+    // which can happen when inserting media inline and switching to HTML mode and back, or by deleting line breaks
+    // in HTML mode
+    mutatedHTML = mutatedHTML.replace(/<br \/>(?=\s*(<a href|<img|<video|<span class="edit-container"))/igm,
+            '</div><div>');
+    mutatedHTML = mutatedHTML.replace(/(<img [^<>]*>|<\/a>|<\/video>|<\/span>)<br \/>/igm,
+            function replaceBrWithDivs(match) { return match.substr(0, match.length - 6) + '</div><div>'; });
+
+    // if document ends with media item and </div>, add <div><br></div>? to fix that last media issue
+    return mutatedHTML;
+}
+
+/**
+ *  @brief      Applies editor specific visual formatting.
+ *
+ *  @param      html   The markup to format
+ *
+ *  @return     Returns the string with the visual formatting applied.
+ */
+Formatter.applyVisualFormatting  = function(html) {
+    var str = wp.shortcode.replace('caption', html, Formatter.applyCaptionFormatting);
+    str = wp.shortcode.replace('wpvideo', str, Formatter.applyVideoPressFormattingCallback);
+    str = wp.shortcode.replace('video', str, Formatter.applyVideoFormattingCallback);
+
+    // More tag
+    str = str.replace(/<!--more(.*?)-->/igm, "<hr class=\"more-tag\" wp-more-data=\"$1\">")
+    str = str.replace(/<!--nextpage-->/igm, "<hr class=\"nextpage-tag\">")
+    return str;
+}
+
+/**
+ *  @brief      Adds visual formatting to a caption shortcodes.
+ *
+ *  @param      html   The markup containing caption shortcodes to process.
+ *
+ *  @return     The html with caption shortcodes replaced with editor specific markup.
+ *  See shortcode.js::next or details
+ */
+Formatter.applyCaptionFormatting = function(match) {
+    var attrs = match.attrs.named;
+    // The empty 'onclick' is important. It prevents the cursor jumping to the end
+    // of the content body when `-webkit-user-select: none` is set and the caption is tapped.
+    var out = '<label class="wp-temp" data-wp-temp="caption" contenteditable="false" onclick="">';
+    out += '<span class="wp-caption"';
+
+    if (attrs.width) {
+        out += ' style="width:' + attrs.width + 'px; max-width:100% !important;"';
+    }
+    $.each(attrs, function(key, value) {
+        out += " data-caption-" + key + '="' + value + '"';
+    });
+
+    out += '>';
+    out += match.content;
+    out += '</span>';
+    out += '</label>';
+
+    return out;
+}
+
+Formatter.applyVideoPressFormattingCallback = function(match) {
+    if (match.attrs.numeric.length == 0) {
+        return match.content;
+    }
+    var videopressID = match.attrs.numeric[0];
+    var posterSVG = '"svg/wpposter.svg"';
+    // The empty 'onclick' is important. It prevents the cursor jumping to the end
+    // of the content body when `-webkit-user-select: none` is set and the video is tapped.
+    var out = '<video data-wpvideopress="' + videopressID + '" webkit-playsinline src="" preload="metadata" poster='
+           + posterSVG +' onclick="" onerror="ZSSEditor.sendVideoPressInfoRequest(\'' + videopressID +'\');"></video>';
+
+    // Wrap video in edit-container node for a permanent delete button overlay
+    var containerStart = '<span class="edit-container" contenteditable="false"><span class="delete-overlay"></span>';
+    out = containerStart + out + '</span>';
+
+    return out;
+}
+
+Formatter.applyVideoFormattingCallback = function(match) {
+    // Find the tag containing the video source
+    var srcTag = "";
+
+    if (match.attrs.named['src']) {
+        srcTag = "src";
+    } else {
+        for (var i = 0; i < Formatter.videoShortcodeFormats.length; i++) {
+            var format = Formatter.videoShortcodeFormats[i];
+            if (match.attrs.named[format]) {
+                srcTag = format;
+                break;
+            }
+        }
+    }
+
+    if (srcTag.length == 0) {
+        return match.content;
+    }
+
+    var out = '<video webkit-playsinline src="' + match.attrs.named[srcTag] + '"';
+
+    // Preserve all existing tags
+    for (var item in match.attrs.named) {
+        if (item != srcTag) {
+            out += ' ' + item + '="' + match.attrs.named[item] + '"';
+        }
+    }
+
+    if (!match.attrs.named['preload']) {
+        out += ' preload="metadata"';
+    }
+
+    out += ' onclick="" controls="controls"></video>';
+
+    // Wrap video in edit-container node for a permanent delete button overlay
+    var containerStart = '<span class="edit-container" contenteditable="false"><span class="delete-overlay"></span>';
+    out = containerStart + out + '</span>';
+
+    return out;
+}

--- a/libs/editor-common/assets/test/test-formatter.js
+++ b/libs/editor-common/assets/test/test-formatter.js
@@ -1,0 +1,122 @@
+var assert = require('chai').assert;
+var underscore = require('../underscore-min.js');
+
+// Set up globals needed by shortcode, wpload, and wpsave
+global.window = {};
+global._ = underscore;
+global.wp = {};
+
+// wp-admin libraries
+var shortcode = require("../shortcode.js");
+var wpload = require("../wpload.js");
+var wpsave = require("../wpsave.js");
+
+var formatterlib = require("../editor-utils-formatter.js");
+var formatter = formatterlib.Formatter;
+
+// Media strings
+
+// Image strings
+var imageSrc = 'content://com.android.providers.media.documents/document/image%3A12951';
+var plainImageHtml = '<img src="' + imageSrc + '" alt="" class="wp-image-123 size-full" width="172" height="244">';
+var imageWrappedInLinkHtml = '<a href="' + imageSrc + '">' + plainImageHtml + '</a>';
+
+// Video strings
+var videoSrc = 'content://com.android.providers.media.documents/document/video%3A12966';
+var videoShortcode = '[video src="' + videoSrc + '" poster=""][/video]';
+var videoHtml = '<span class="edit-container" contenteditable="false"><span class="delete-overlay"></span>' +
+    '<video webkit-playsinline src="' + videoSrc + '" poster="" preload="metadata" onclick="" controls="controls">' +
+    '</video></span>';
+
+// VideoPress video strings
+var vpVideoShortcode = '[wpvideo ABCD1234]';
+var vpVideoHtml = '<span class="edit-container" contenteditable="false"><span class="delete-overlay"></span>' +
+    '<video data-wpvideopress="ABCD1234" webkit-playsinline src="" preload="metadata" poster="svg/wpposter.svg" ' +
+    'onclick="" onerror="ZSSEditor.sendVideoPressInfoRequest(\'ABCD1234\');"></video></span>';
+
+describe('HTML to Visual formatter should correctly convert', function () {
+  it('single-line HTML', function () {
+    assert.equal('<p>Some text</p>\n', formatter.htmlToVisual('Some text'));
+  });
+
+  it('multi-paragraph HTML', function () {
+    assert.equal('<p>Some text</p>\n<p>More text</p>\n', formatter.htmlToVisual('Some text\n\nMore text'));
+  });
+
+  testMediaParagraphWrapping('image wrapped in link', plainImageHtml, plainImageHtml);
+  testMediaParagraphWrapping('image not wrapped in link', imageWrappedInLinkHtml, imageWrappedInLinkHtml);
+  testMediaParagraphWrapping('non-VideoPress video', videoShortcode, videoHtml);
+  testMediaParagraphWrapping('VideoPress video', vpVideoShortcode, vpVideoHtml);
+});
+
+function testMediaParagraphWrapping(mediaType, htmlModeMediaHtml, visualModeMediaHtml) {
+  describe(mediaType, function () {
+    it('alone in post', function () {
+      var visualFormattingApplied = formatter.htmlToVisual(htmlModeMediaHtml);
+      assert.equal('<p>' + visualModeMediaHtml + '</p>\n', visualFormattingApplied);
+
+      var convertedToDivs = formatter.convertPToDiv(visualFormattingApplied).replace(/\n/g, '');
+      assert.equal('<div>' + visualModeMediaHtml + '</div>', convertedToDivs);
+    });
+
+    it('with paragraphs above and below', function () {
+      var imageBetweenParagraphs = 'Line 1\n\n' + htmlModeMediaHtml + '\n\nLine 2';
+
+      var visualFormattingApplied = formatter.htmlToVisual(imageBetweenParagraphs);
+      assert.equal('<p>Line 1</p>\n<p>' + visualModeMediaHtml + '</p>\n<p>Line 2</p>\n', visualFormattingApplied);
+
+      var convertedToDivs = formatter.convertPToDiv(visualFormattingApplied).replace(/\n/g, '');
+      assert.equal('<div>Line 1</div><div>' + visualModeMediaHtml + '</div><div>Line 2</div>', convertedToDivs);
+    });
+
+    it('with line breaks above and below', function () {
+      var imageBetweenLineBreaks = 'Line 1\n' + htmlModeMediaHtml + '\nLine 2';
+
+      var visualFormattingApplied = formatter.htmlToVisual(imageBetweenLineBreaks);
+      assert.equal('<p>Line 1<br />\n' + visualModeMediaHtml + '<br />\nLine 2</p>\n', visualFormattingApplied);
+
+      var convertedToDivs = formatter.convertPToDiv(visualFormattingApplied).replace(/\n/g, '');
+      assert.equal('<div>Line 1</div><div>' + visualModeMediaHtml + '</div><div>Line 2</div>', convertedToDivs);
+    });
+
+    it('start of post, with paragraph underneath', function () {
+      var imageFollowedByParagraph = htmlModeMediaHtml + '\n\nLine 2';
+
+      var visualFormattingApplied = formatter.htmlToVisual(imageFollowedByParagraph);
+      assert.equal('<p>' + visualModeMediaHtml + '</p>\n<p>Line 2</p>\n', visualFormattingApplied);
+
+      var convertedToDivs = formatter.convertPToDiv(visualFormattingApplied).replace(/\n/g, '');
+      assert.equal('<div>' + visualModeMediaHtml + '</div><div>Line 2</div>', convertedToDivs);
+    });
+
+    it('start of post, with line break underneath', function () {
+      var imageFollowedByLineBreak = htmlModeMediaHtml + '\nLine 2';
+
+      var visualFormattingApplied = formatter.htmlToVisual(imageFollowedByLineBreak);
+      assert.equal('<p>' + visualModeMediaHtml + '<br \/>\nLine 2</p>\n', visualFormattingApplied);
+
+      var convertedToDivs = formatter.convertPToDiv(visualFormattingApplied).replace(/\n/g, '');
+      assert.equal('<div>' + visualModeMediaHtml + '</div><div>Line 2</div>', convertedToDivs);
+    });
+
+    it('end of post, with paragraph above', function () {
+      var imageUnderParagraph = 'Line 1\n\n' + htmlModeMediaHtml;
+
+      var visualFormattingApplied = formatter.htmlToVisual(imageUnderParagraph);
+      assert.equal('<p>Line 1</p>\n<p>' + visualModeMediaHtml + '</p>\n', visualFormattingApplied);
+
+      var convertedToDivs = formatter.convertPToDiv(visualFormattingApplied).replace(/\n/g, '');
+      assert.equal('<div>Line 1</div><div>' + visualModeMediaHtml + '</div>', convertedToDivs);
+    });
+
+    it('end of post, with line break above', function () {
+      var imageUnderLineBreak = 'Line 1\n' + htmlModeMediaHtml;
+
+      var visualFormattingApplied = formatter.htmlToVisual(imageUnderLineBreak);
+      assert.equal('<p>Line 1<br \/>\n' + visualModeMediaHtml + '</p>\n', visualFormattingApplied);
+
+      var convertedToDivs = formatter.convertPToDiv(visualFormattingApplied).replace(/\n/g, '');
+      assert.equal('<div>Line 1</div><div>' + visualModeMediaHtml + '</div>', convertedToDivs);
+    });
+  });
+}


### PR DESCRIPTION
Adds JS unit tests using Mocha. For now, the tests check paragraph formatting when loading HTML into the visual editor.

To build tests without relying on the full `ZSSEditor` or the DOM, I refactored some of the HTML-to-visual conversion code to make it functional, and extracted as many methods as possible to a new helper file, `editor-utils-formatter.js`, against which the tests are run.

To run the tests, `npm` must be installed, as well as `Mocha` (see the [updated README](https://github.com/wordpress-mobile/WordPress-Editor-Android/blob/04b81e352cd1a2acf437b52b1dfe363f23ff3258/README.md#javascript-tests) for full instructions).

Hat-tip to @v18 for guidance with setting up Mocha tests 😀.

cc @maxme 
