### PR TITLE
Issue #409: Difficulty setting the cursor under media

### DIFF
--- a/libs/editor-common/assets/editor-utils-formatter.js
+++ b/libs/editor-common/assets/editor-utils-formatter.js
@@ -23,8 +23,8 @@ Formatter.convertPToDiv = function(html) {
             function replaceBrWithDivs(match) { return match.substr(0, match.length - 6) + '</div><div>'; });
 
     // Append paragraph-wrapped break tag under media at the end of a post
-    mutatedHTML = mutatedHTML.replace(/(<img [^<>]*>|<\/a>|<\/video>|<\/span>)<\/div>\s$/igm,
-             function replaceBrWithDivs(match) { return match + '<div><br></div>'; });
+    mutatedHTML = mutatedHTML.replace(/(<img [^<>]*>|<\/a>|<\/video>|<\/span>)[^<>]*<\/div>\s$/igm,
+            function replaceBrWithDivs(match) { return match + '<div><br></div>'; });
 
     return mutatedHTML;
 }

--- a/libs/editor-common/assets/editor-utils-formatter.js
+++ b/libs/editor-common/assets/editor-utils-formatter.js
@@ -22,6 +22,10 @@ Formatter.convertPToDiv = function(html) {
     mutatedHTML = mutatedHTML.replace(/(<img [^<>]*>|<\/a>|<\/video>|<\/span>)<br \/>/igm,
             function replaceBrWithDivs(match) { return match.substr(0, match.length - 6) + '</div><div>'; });
 
+    // Append paragraph-wrapped break tag under media at the end of a post
+    mutatedHTML = mutatedHTML.replace(/(<img [^<>]*>|<\/a>|<\/video>|<\/span>)<\/div>\s$/igm,
+             function replaceBrWithDivs(match) { return match + '<div><br></div>'; });
+
     return mutatedHTML;
 }
 

--- a/libs/editor-common/assets/test/test-formatter.js
+++ b/libs/editor-common/assets/test/test-formatter.js
@@ -56,7 +56,7 @@ function testMediaParagraphWrapping(mediaType, htmlModeMediaHtml, visualModeMedi
       assert.equal('<p>' + visualModeMediaHtml + '</p>\n', visualFormattingApplied);
 
       var convertedToDivs = formatter.convertPToDiv(visualFormattingApplied).replace(/\n/g, '');
-      assert.equal('<div>' + visualModeMediaHtml + '</div>', convertedToDivs);
+      assert.equal('<div>' + visualModeMediaHtml + '</div><div><br></div>', convertedToDivs);
     });
 
     it('with paragraphs above and below', function () {
@@ -106,7 +106,7 @@ function testMediaParagraphWrapping(mediaType, htmlModeMediaHtml, visualModeMedi
       assert.equal('<p>Line 1</p>\n<p>' + visualModeMediaHtml + '</p>\n', visualFormattingApplied);
 
       var convertedToDivs = formatter.convertPToDiv(visualFormattingApplied).replace(/\n/g, '');
-      assert.equal('<div>Line 1</div><div>' + visualModeMediaHtml + '</div>', convertedToDivs);
+      assert.equal('<div>Line 1</div><div>' + visualModeMediaHtml + '</div><div><br></div>', convertedToDivs);
     });
 
     it('end of post, with line break above', function () {
@@ -116,7 +116,7 @@ function testMediaParagraphWrapping(mediaType, htmlModeMediaHtml, visualModeMedi
       assert.equal('<p>Line 1<br \/>\n' + visualModeMediaHtml + '</p>\n', visualFormattingApplied);
 
       var convertedToDivs = formatter.convertPToDiv(visualFormattingApplied).replace(/\n/g, '');
-      assert.equal('<div>Line 1</div><div>' + visualModeMediaHtml + '</div>', convertedToDivs);
+      assert.equal('<div>Line 1</div><div>' + visualModeMediaHtml + '</div><div><br></div>', convertedToDivs);
     });
   });
 }


### PR DESCRIPTION
Fixes #409. When loading a post (either by loading from DB or by switching from HTML mode), the editor will now append a new paragraph after media items, allowing the user to easily place the cursor under the media item.

This should have no effect on posts being published in WPAndroid, as any trailing spaces or break tags are stripped by the editor when extracting the post from the visual editor.

cc @maxme 
