### PR TITLE
Issue #421: Failed videos aren't cleared correctly when switching to HTML mode

### DIFF
--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1147,6 +1147,14 @@ ZSSEditor.sendOptimisticProgressUpdate = function(mediaNodeIdentifier, nCall) {
     ZSSEditor.setupOptimisticProgressUpdate(mediaNodeIdentifier, nCall + 1);
 };
 
+ZSSEditor.removeAllFailedMediaUploads = function() {
+    console.log("Remove all failed media");
+    var failedMediaArray = ZSSEditor.getFailedMediaIdArray();
+    for (var i = 0; i < failedMediaArray.length; i++) {
+        ZSSEditor.removeMedia(failedMediaArray[i]);
+    }
+};
+
 ZSSEditor.removeMedia = function(mediaNodeIdentifier) {
     if (this.getImageNodeWithIdentifier(mediaNodeIdentifier).length != 0) {
         this.removeImage(mediaNodeIdentifier);
@@ -1521,14 +1529,6 @@ ZSSEditor.removeImage = function(imageNodeIdentifier) {
         imageContainerNode.remove();
     }
 };
-
-ZSSEditor.removeAllFailedMediaUploads = function() {
-    console.log("Remove all failed media");
-    var failedMediaArray = ZSSEditor.getFailedMediaIdArray();
-    for (var i = 0; i < failedMediaArray.length; i++) {
-        ZSSEditor.removeMedia(failedMediaArray[i]);
-    }
-}
 
 /**
  *  @brief Inserts a video tag using the videoURL as source and posterURL as the

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1147,6 +1147,14 @@ ZSSEditor.sendOptimisticProgressUpdate = function(mediaNodeIdentifier, nCall) {
     ZSSEditor.setupOptimisticProgressUpdate(mediaNodeIdentifier, nCall + 1);
 };
 
+ZSSEditor.removeMedia = function(mediaNodeIdentifier) {
+    if (this.getImageNodeWithIdentifier(mediaNodeIdentifier).length != 0) {
+        this.removeImage(mediaNodeIdentifier);
+    } else if (this.getVideoNodeWithIdentifier(mediaNodeIdentifier).length != 0) {
+        this.removeVideo(mediaNodeIdentifier);
+    }
+};
+
 ZSSEditor.sendMediaRemovedCallback = function(mediaNodeIdentifier) {
     var arguments = ['id=' + encodeURIComponent(mediaNodeIdentifier)];
     var joinedArguments = arguments.join(defaultCallbackSeparator);
@@ -1518,7 +1526,7 @@ ZSSEditor.removeAllFailedMediaUploads = function() {
     console.log("Remove all failed media");
     var failedMediaArray = ZSSEditor.getFailedMediaIdArray();
     for (var i = 0; i < failedMediaArray.length; i++) {
-        ZSSEditor.removeImage(failedMediaArray[i]);
+        ZSSEditor.removeMedia(failedMediaArray[i]);
     }
 }
 


### PR DESCRIPTION
Fixes #421. The problem was that `ZSSEditor.removeAllFailedMediaUploads()` was only attempting to remove images, so any failed video HTML would be left in the post.

cc @maxme
