### PR TITLE
Issue #423: Can't backspace to delete images with captions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ With npm and Mocha installed, from within `libs/editor-common/assets/test`, run:
 
     npm install chai
 
-It should now be possible to run the tests using `mocha` inside `libs/editor-common/assets`.
+And then run `mocha` inside `libs/editor-common/assets`:
+
+    cd libs/editor-common/assets; mocha; cd -
 
 ## LICENSE ##
 

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3227,6 +3227,9 @@ ZSSField.prototype.handleKeyDownEvent = function(e) {
             } else if (sel.isCollapsed && sel.baseOffset == 0 && parentNode && parentNode.nodeName == 'BLOCKQUOTE') {
                 e.preventDefault();
                 ZSSEditor.setBlockquote();
+            // When pressing enter inside an image caption, clear the caption styling from the new line
+            } else if (parentNode.nodeName == NodeName.SPAN && $(parentNode).hasClass('wp-caption')) {
+                setTimeout(this.handleCaptionEnter, 100);
             }
         }
     }
@@ -3634,6 +3637,27 @@ ZSSField.prototype.wrapCaretInParagraphIfNecessary = function() {
             }
         }
     }
+};
+
+/**
+ *  @brief      Called when enter is pressed inside an image caption. Clears away the span and label tags the new line
+ *              inherits from the caption styling.
+ */
+ZSSField.prototype.handleCaptionEnter = function() {
+    var selection = document.getSelection();
+
+    var contentsNode = selection.baseNode.firstChild.cloneNode();
+
+    var parentSpan = selection.baseNode.parentNode.parentNode;
+    var parentDiv = parentSpan.parentNode;
+
+    var paragraph = document.createElement("div");
+    paragraph.appendChild(contentsNode);
+
+    parentDiv.insertBefore(paragraph, parentSpan);
+    parentDiv.removeChild(parentSpan);
+
+    ZSSEditor.giveFocusToElement(contentsNode);
 };
 
 // MARK: - i18n

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1942,11 +1942,15 @@ ZSSEditor.updateCurrentImageMeta = function( imageMetaString ) {
     // in certain cases, modify the current and inserted markup depending on what
     // elements surround the targeted node.  This approach is safer.
     var node = ZSSEditor.findImageCaptionNode( ZSSEditor.currentEditingImage );
+    var parent = node.parentNode;
+
     node.insertAdjacentHTML( 'afterend', html );
     // Use {node}.{parent}.removeChild() instead of {node}.remove(), since Android API<19 doesn't support Node.remove()
     node.parentNode.removeChild(node);
 
     ZSSEditor.currentEditingImage = null;
+
+    ZSSEditor.setFocusAfterElement(parent);
 }
 
 ZSSEditor.applyImageSelectionFormatting = function( imageNode ) {

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -2152,7 +2152,7 @@ ZSSEditor.createImageFromMeta = function( props ) {
         html = wp.shortcode.string({
             tag:     'caption',
             attrs:   shortcode,
-            content: html + ' ' + props.caption
+            content: html + props.caption
         });
 
         html = Formatter.applyVisualFormatting( html );

--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3229,7 +3229,7 @@ ZSSField.prototype.handleKeyDownEvent = function(e) {
                 ZSSEditor.setBlockquote();
             // When pressing enter inside an image caption, clear the caption styling from the new line
             } else if (parentNode.nodeName == NodeName.SPAN && $(parentNode).hasClass('wp-caption')) {
-                setTimeout(this.handleCaptionEnter, 100);
+                setTimeout(this.handleCaptionNewLine, 100);
             }
         }
     }
@@ -3643,12 +3643,17 @@ ZSSField.prototype.wrapCaretInParagraphIfNecessary = function() {
  *  @brief      Called when enter is pressed inside an image caption. Clears away the span and label tags the new line
  *              inherits from the caption styling.
  */
-ZSSField.prototype.handleCaptionEnter = function() {
-    var selection = document.getSelection();
+ZSSField.prototype.handleCaptionNewLine = function() {
+    var selectedNode = document.getSelection().baseNode;
 
-    var contentsNode = selection.baseNode.firstChild.cloneNode();
+    var contentsNode;
+    if (selectedNode.firstChild != null) {
+        contentsNode = selectedNode.firstChild.cloneNode();
+    } else {
+        contentsNode = selectedNode.cloneNode();
+    }
 
-    var parentSpan = selection.baseNode.parentNode.parentNode;
+    var parentSpan = selectedNode.parentNode.parentNode;
     var parentDiv = parentSpan.parentNode;
 
     var paragraph = document.createElement("div");

--- a/libs/editor-common/assets/editor-utils-formatter.js
+++ b/libs/editor-common/assets/editor-utils-formatter.js
@@ -6,6 +6,13 @@ Formatter.videoShortcodeFormats = ["mp4", "m4v", "webm", "ogv", "wmv", "flv"];
 
 Formatter.htmlToVisual = function(html) {
     var mutatedHTML = wp.loadText(html);
+
+    // Perform extra transformations to properly wrap captioned images in paragraphs
+    mutatedHTML = mutatedHTML.replace(/^\[caption([^\]]*\])/igm, '<p>[caption$1');
+    mutatedHTML = mutatedHTML.replace(/([^\n>])\[caption/igm, '$1<br />\n[caption');
+    mutatedHTML = mutatedHTML.replace(/\[\/caption\]\n(?=<|$)/igm, '[/caption]</p>\n');
+    mutatedHTML = mutatedHTML.replace(/\[\/caption\]\n(?=[^<])/igm, '[/caption]<br />\n');
+
     return Formatter.applyVisualFormatting(mutatedHTML);
 }
 

--- a/libs/editor-common/assets/editor-utils-formatter.js
+++ b/libs/editor-common/assets/editor-utils-formatter.js
@@ -68,7 +68,7 @@ Formatter.applyCaptionFormatting = function(match) {
     var attrs = match.attrs.named;
     // The empty 'onclick' is important. It prevents the cursor jumping to the end
     // of the content body when `-webkit-user-select: none` is set and the caption is tapped.
-    var out = '<label class="wp-temp" data-wp-temp="caption" contenteditable="false" onclick="">';
+    var out = '<label class="wp-temp" data-wp-temp="caption" onclick="">';
     out += '<span class="wp-caption"';
 
     if (attrs.width) {

--- a/libs/editor-common/assets/editor-utils-formatter.js
+++ b/libs/editor-common/assets/editor-utils-formatter.js
@@ -17,13 +17,13 @@ Formatter.convertPToDiv = function(html) {
     // The break tags appear when text and media are separated by only a line break rather than a paragraph break,
     // which can happen when inserting media inline and switching to HTML mode and back, or by deleting line breaks
     // in HTML mode
-    mutatedHTML = mutatedHTML.replace(/<br \/>(?=\s*(<a href|<img|<video|<span class="edit-container"))/igm,
+    mutatedHTML = mutatedHTML.replace(/<br \/>(?=\s*(<img|<a href|<label|<video|<span class="edit-container"))/igm,
             '</div><div>');
-    mutatedHTML = mutatedHTML.replace(/(<img [^<>]*>|<\/a>|<\/video>|<\/span>)<br \/>/igm,
+    mutatedHTML = mutatedHTML.replace(/(<img [^<>]*>|<\/a>|<\/label>|<\/video>|<\/span>)<br \/>/igm,
             function replaceBrWithDivs(match) { return match.substr(0, match.length - 6) + '</div><div>'; });
 
     // Append paragraph-wrapped break tag under media at the end of a post
-    mutatedHTML = mutatedHTML.replace(/(<img [^<>]*>|<\/a>|<\/video>|<\/span>)[^<>]*<\/div>\s$/igm,
+    mutatedHTML = mutatedHTML.replace(/(<img [^<>]*>|<\/a>|<\/label>|<\/video>|<\/span>)[^<>]*<\/div>\s$/igm,
             function replaceBrWithDivs(match) { return match + '<div><br></div>'; });
 
     return mutatedHTML;

--- a/libs/editor-common/assets/editor-utils-formatter.js
+++ b/libs/editor-common/assets/editor-utils-formatter.js
@@ -74,9 +74,9 @@ Formatter.applyCaptionFormatting = function(match) {
     if (attrs.width) {
         out += ' style="width:' + attrs.width + 'px; max-width:100% !important;"';
     }
-    $.each(attrs, function(key, value) {
-        out += " data-caption-" + key + '="' + value + '"';
-    });
+    for (var key in attrs) {
+        out += " data-caption-" + key + '="' + attrs[key] + '"';
+    }
 
     out += '>';
     out += match.content;

--- a/libs/editor-common/assets/test/test-formatter.js
+++ b/libs/editor-common/assets/test/test-formatter.js
@@ -43,8 +43,8 @@ describe('HTML to Visual formatter should correctly convert', function () {
     assert.equal('<p>Some text</p>\n<p>More text</p>\n', formatter.htmlToVisual('Some text\n\nMore text'));
   });
 
-  testMediaParagraphWrapping('image wrapped in link', plainImageHtml, plainImageHtml);
-  testMediaParagraphWrapping('image not wrapped in link', imageWrappedInLinkHtml, imageWrappedInLinkHtml);
+  testMediaParagraphWrapping('non-linked image', plainImageHtml, plainImageHtml);
+  testMediaParagraphWrapping('linked image', imageWrappedInLinkHtml, imageWrappedInLinkHtml);
   testMediaParagraphWrapping('non-VideoPress video', videoShortcode, videoHtml);
   testMediaParagraphWrapping('VideoPress video', vpVideoShortcode, vpVideoHtml);
 });

--- a/libs/editor-common/assets/test/test-formatter.js
+++ b/libs/editor-common/assets/test/test-formatter.js
@@ -21,6 +21,16 @@ var imageSrc = 'content://com.android.providers.media.documents/document/image%3
 var plainImageHtml = '<img src="' + imageSrc + '" alt="" class="wp-image-123 size-full" width="172" height="244">';
 var imageWrappedInLinkHtml = '<a href="' + imageSrc + '">' + plainImageHtml + '</a>';
 
+// Captioned image strings
+var imageCaptionShortcode = '[caption width="600" align="alignnone"]' + imageSrc + 'Text[/caption]';
+var imageWithCaptionHtml = '<label class="wp-temp" data-wp-temp="caption" onclick="">' +
+    '<span class="wp-caption" style="width:600px; max-width:100% !important;" data-caption-width="600" ' +
+    'data-caption-align="alignnone">' + imageSrc + 'Text</span></label>';
+var linkedImageCaptionShortcode = '[caption width="600" align="alignnone"]' + imageWrappedInLinkHtml + 'Text[/caption]';
+var linkedImageCaptionHtml = '<label class="wp-temp" data-wp-temp="caption" onclick="">' +
+    '<span class="wp-caption" style="width:600px; max-width:100% !important;" data-caption-width="600" ' +
+    'data-caption-align="alignnone">' + imageWrappedInLinkHtml + 'Text</span></label>';
+
 // Video strings
 var videoSrc = 'content://com.android.providers.media.documents/document/video%3A12966';
 var videoShortcode = '[video src="' + videoSrc + '" poster=""][/video]';
@@ -45,6 +55,8 @@ describe('HTML to Visual formatter should correctly convert', function () {
 
   testMediaParagraphWrapping('non-linked image', plainImageHtml, plainImageHtml);
   testMediaParagraphWrapping('linked image', imageWrappedInLinkHtml, imageWrappedInLinkHtml);
+  testMediaParagraphWrapping('non-linked image, with caption', imageCaptionShortcode, imageWithCaptionHtml);
+  testMediaParagraphWrapping('linked image, with caption', linkedImageCaptionShortcode, linkedImageCaptionHtml);
   testMediaParagraphWrapping('non-VideoPress video', videoShortcode, videoHtml);
   testMediaParagraphWrapping('VideoPress video', vpVideoShortcode, vpVideoHtml);
 });


### PR DESCRIPTION
Fixes #423.

For some reason, the cursor position gets reset when backspacing into an image with a caption. I could not reproduce the issue on emulators (using hardware or software keyboard), and I think this is another autocorrect+WebView bug.

The best fix I found was to make captions editable (previously they had `contenteditable="false"`). This allows backspace to focus on the caption, and backspacing after the caption is deleted will remove the image as expected (I guess this is actually a feature 🎉).

I also extended the changes of https://github.com/wordpress-mobile/WordPress-Editor-Android/pull/418 and https://github.com/wordpress-mobile/WordPress-Editor-Android/pull/420 to captioned images in this PR (properly wrapping media in paragraphs when switching from HTML to visual, and adding an empty space under media under the same circumstances).

The `wp.loadText` method we're using doesn't treat captions the same way as other media, so a few extensions had to be added (in `editor-utils-formatter.js`) to treat captions the same way (3f15fa3). I also extended the JS tests to check for this.

cc @maxme 
