### PR TITLE
Issue #204: Can't start a post with formatted text

### DIFF
--- a/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -2584,6 +2584,31 @@ ZSSEditor.sendEnabledStyles = function(e) {
 	ZSSEditor.stylesCallback(items);
 };
 
+ZSSEditor.storeInlineStylesAsFunctions = function() {
+    var styles = [];
+
+    if (ZSSEditor.isCommandEnabled('bold')) {
+        styles.push(ZSSEditor.setBold);
+    }
+    if (ZSSEditor.isCommandEnabled('italic')) {
+        styles.push(ZSSEditor.setItalic);
+    }
+    if (ZSSEditor.isCommandEnabled('strikeThrough')) {
+        styles.push(ZSSEditor.setStrikeThrough);
+    }
+    if (ZSSEditor.isCommandEnabled('underline')) {
+        styles.push(ZSSEditor.setUnderline);
+    }
+    if (ZSSEditor.isCommandEnabled('subscript')) {
+        styles.push(ZSSEditor.setSubscript);
+    }
+    if (ZSSEditor.isCommandEnabled('superscript')) {
+        styles.push(ZSSEditor.setSuperscript);
+    }
+
+    return styles;
+};
+
 // MARK: - Commands: High Level Editing
 
 /**
@@ -3628,6 +3653,14 @@ ZSSField.prototype.wrapCaretInParagraphIfNecessary = function() {
                     closerParentNode.removeChild(closerParentNode.firstChild);
                 }
 
+                var storedStyles = [];
+                if (this.getWrappedDomNode().innerHTML.length == 0) {
+                    // If the post is empty, store any active in-line formatting so it can be re-applied after the
+                    // DOM manipulations are completed
+                    // (Fix for https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/204)
+                    storedStyles = ZSSEditor.storeInlineStylesAsFunctions();
+                }
+
                 var paragraph = document.createElement("div");
                 var textNode = document.createTextNode("&#x200b;");
 
@@ -3638,6 +3671,11 @@ ZSSField.prototype.wrapCaretInParagraphIfNecessary = function() {
 
                 selection.removeAllRanges();
                 selection.addRange(range);
+
+                // Re-apply inline styles that were cleared
+                storedStyles.map(function(styleFunction) {
+                    styleFunction();
+                });
             }
         }
     }


### PR DESCRIPTION
Fixes #204.

The issue was that our start-of-post paragraph manipulations were clearing away any formatting that the user had enabled before starting to type. A manual storing + re-applying the formatting did the trick.

cc @maxme
