### PR TITLE
Issue #429: HTML mode styling crash

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/HtmlStyleTextWatcher.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/HtmlStyleTextWatcher.java
@@ -192,6 +192,12 @@ public class HtmlStyleTextWatcher implements TextWatcher {
         if (spanStart > content.length() || spanEnd > content.length()) {
             AppLog.d(T.EDITOR, "The specified span range was beyond the Spannable's length");
             return;
+        } else if (spanStart >= spanEnd) {
+            // If the span start is after the end position (probably due to a multi-line deletion), selective
+            // re-styling won't work
+            // Instead, do a clean re-styling of the whole document
+            spanStart = 0;
+            spanEnd = content.length();
         }
 
         HtmlStyleUtils.clearSpans(content, spanStart, spanEnd);

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/HtmlStyleUtils.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/HtmlStyleUtils.java
@@ -98,7 +98,8 @@ public class HtmlStyleUtils {
      * @param regex the pattern to match for styling
      */
     private static void applySpansByRegex(Spannable content, int start, int end, String regex) {
-        if (content == null || start < 0 || end < 0 || start > content.length() || end > content.length()) {
+        if (content == null || start < 0 || end < 0 || start > content.length() || end > content.length() ||
+                start >= end) {
             AppLog.d(AppLog.T.EDITOR, "applySpansByRegex() received invalid input");
             return;
         }


### PR DESCRIPTION
Fixes #429. The issue can be reproduced by deleting multiple lines of text containing tags in HTML mode (the example post, selecting down to the list elements, worked every time for me).

cc @maxme 
