### PR TITLE
Issue #432: evaluateJavaScript not supported

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -26,6 +26,7 @@ import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.webkit.URLUtil;
 import android.webkit.WebView;
+import android.widget.RelativeLayout.LayoutParams;
 import android.widget.ToggleButton;
 
 import com.android.volley.toolbox.ImageLoader;
@@ -154,6 +155,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             int index = parent.indexOfChild(mWebView);
             parent.removeView(mWebView);
             mWebView = new EditorWebViewCompatibility(getActivity(), null);
+            mWebView.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
             parent.addView(mWebView, index);
         }
 

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -148,6 +148,15 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
         mWebView = (EditorWebViewAbstract) view.findViewById(R.id.webview);
 
+        // Revert to compatibility WebView for custom ROMs using a 4.3 WebView in Android 4.4
+        if (mWebView.shouldSwitchToCompatibilityMode()) {
+            ViewGroup parent = (ViewGroup) mWebView.getParent();
+            int index = parent.indexOfChild(mWebView);
+            parent.removeView(mWebView);
+            mWebView = new EditorWebViewCompatibility(getActivity(), null);
+            parent.addView(mWebView, index);
+        }
+
         mWebView.setOnTouchListener(this);
         mWebView.setOnImeBackListener(this);
         mWebView.setAuthHeaderRequestListener(this);

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebView.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebView.java
@@ -13,11 +13,19 @@ public class EditorWebView extends EditorWebViewAbstract {
 
     @SuppressLint("NewApi")
     public void execJavaScriptFromString(String javaScript) {
-        if (Build.VERSION.SDK_INT >= 19) {
-            this.evaluateJavascript(javaScript, null);
-        } else {
-            this.loadUrl("javascript:" + javaScript);
-        }
+        this.evaluateJavascript(javaScript, null);
     }
 
+    @SuppressLint("NewApi")
+    @Override
+    public boolean shouldSwitchToCompatibilityMode() {
+        if (Build.VERSION.SDK_INT <= 19) {
+            try {
+                this.evaluateJavascript("", null);
+            } catch (NoSuchMethodError | IllegalStateException e) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebView.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebView.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import android.os.Build;
 import android.util.AttributeSet;
 
+import org.wordpress.android.util.AppLog;
+
 public class EditorWebView extends EditorWebViewAbstract {
 
     public EditorWebView(Context context, AttributeSet attrs) {
@@ -23,6 +25,8 @@ public class EditorWebView extends EditorWebViewAbstract {
             try {
                 this.evaluateJavascript("", null);
             } catch (NoSuchMethodError | IllegalStateException e) {
+                AppLog.d(AppLog.T.EDITOR,
+                        "Detected 4.4 ROM using classic WebView, reverting to compatibility EditorWebView.");
                 return true;
             }
         }

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebViewAbstract.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebViewAbstract.java
@@ -179,6 +179,11 @@ public abstract class EditorWebViewAbstract extends WebView {
         super.setVisibility(visibility);
     }
 
+
+    public boolean shouldSwitchToCompatibilityMode() {
+        return false;
+    }
+
     public void setDebugModeEnabled(boolean enabled) {
         mDebugModeEnabled = enabled;
     }


### PR DESCRIPTION
Fixes #432. The issue occurs in custom ROMs using the 4.3 'classic' WebView (pre-Chromium) in a Android 4.4 build. Fixed by reverting to the 'compatibility' WebView in those cases, which uses the older `loadUrl` method for executing JavaScript (as well as applying our reflection-based modifications to avoid the keyboard being dismissed on JS execution).

cc @maxme 
