### PR TITLE
Fix #445: translated alignement issue in ImageSettings screen

### DIFF
--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -32,7 +32,6 @@ import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.ToastUtils;
 
 import java.util.Arrays;
-import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -52,6 +51,7 @@ public class ImageSettingsDialogFragment extends DialogFragment {
     private EditText mCaptionText;
     private EditText mAltText;
     private Spinner mAlignmentSpinner;
+    private String[] mAlignmentKeyArray;
     private EditText mLinkTo;
     private EditText mWidthText;
     private CheckBox mFeaturedCheckBox;
@@ -159,12 +159,9 @@ public class ImageSettingsDialogFragment extends DialogFragment {
                 mAltText.setText(mImageMeta.getString("alt"));
 
                 String alignment = mImageMeta.getString("align");
-
-                // Capitalize the alignment value to match the spinner entries
-                alignment = alignment.substring(0, 1).toUpperCase(Locale.US) + alignment.substring(1);
-
-                String[] alignmentArray = getResources().getStringArray(R.array.alignment_array);
-                mAlignmentSpinner.setSelection(Arrays.asList(alignmentArray).indexOf(alignment));
+                mAlignmentKeyArray = getResources().getStringArray(R.array.alignment_key_array);
+                int alignementIndex = Arrays.asList(mAlignmentKeyArray).indexOf(alignment);
+                mAlignmentSpinner.setSelection(alignementIndex == -1 ? 0 : alignementIndex);
 
                 mLinkTo.setText(mImageMeta.getString("linkUrl"));
 
@@ -306,7 +303,9 @@ public class ImageSettingsDialogFragment extends DialogFragment {
             metaData.put("title", mTitleText.getText().toString());
             metaData.put("caption", mCaptionText.getText().toString());
             metaData.put("alt", mAltText.getText().toString());
-            metaData.put("align", mAlignmentSpinner.getSelectedItem().toString().toLowerCase(Locale.US));
+            if (mAlignmentSpinner.getSelectedItemPosition() < mAlignmentKeyArray.length) {
+                metaData.put("align", mAlignmentKeyArray[mAlignmentSpinner.getSelectedItemPosition()]);
+            }
             metaData.put("linkUrl", mLinkTo.getText().toString());
 
             int newWidth = getEditTextIntegerClamped(mWidthText, 10, mMaxImageWidth);

--- a/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -160,8 +160,8 @@ public class ImageSettingsDialogFragment extends DialogFragment {
 
                 String alignment = mImageMeta.getString("align");
                 mAlignmentKeyArray = getResources().getStringArray(R.array.alignment_key_array);
-                int alignementIndex = Arrays.asList(mAlignmentKeyArray).indexOf(alignment);
-                mAlignmentSpinner.setSelection(alignementIndex == -1 ? 0 : alignementIndex);
+                int alignmentIndex = Arrays.asList(mAlignmentKeyArray).indexOf(alignment);
+                mAlignmentSpinner.setSelection(alignmentIndex == -1 ? 0 : alignmentIndex);
 
                 mLinkTo.setText(mImageMeta.getString("linkUrl"));
 

--- a/WordPressEditor/src/main/res/values/strings.xml
+++ b/WordPressEditor/src/main/res/values/strings.xml
@@ -52,10 +52,10 @@
     <string name="image_link_to">Link to</string>
     <string name="image_width">Width</string>
 
-    <string name="alignement_none">None</string>
-    <string name="alignement_left">Left</string>
-    <string name="alignement_center">Center</string>
-    <string name="alignement_right">Right</string>
+    <string name="alignment_none">None</string>
+    <string name="alignment_left">Left</string>
+    <string name="alignment_center">Center</string>
+    <string name="alignment_right">Right</string>
 
     <string-array name="alignment_key_array" translatable="false">
         <item>none</item>
@@ -65,10 +65,10 @@
     </string-array>
 
     <string-array name="alignment_array" translatable="false">
-        <item>@string/alignement_none</item>
-        <item>@string/alignement_left</item>
-        <item>@string/alignement_center</item>
-        <item>@string/alignement_right</item>
+        <item>@string/alignment_none</item>
+        <item>@string/alignment_left</item>
+        <item>@string/alignment_center</item>
+        <item>@string/alignment_right</item>
     </string-array>
 
     <!-- Accessibility - format bar button descriptions -->

--- a/WordPressEditor/src/main/res/values/strings.xml
+++ b/WordPressEditor/src/main/res/values/strings.xml
@@ -52,11 +52,23 @@
     <string name="image_link_to">Link to</string>
     <string name="image_width">Width</string>
 
-    <string-array name="alignment_array">
-        <item>None</item>
-        <item>Left</item>
-        <item>Center</item>
-        <item>Right</item>
+    <string name="alignement_none">None</string>
+    <string name="alignement_left">Left</string>
+    <string name="alignement_center">Center</string>
+    <string name="alignement_right">Right</string>
+
+    <string-array name="alignment_key_array" translatable="false">
+        <item>none</item>
+        <item>left</item>
+        <item>center</item>
+        <item>right</item>
+    </string-array>
+
+    <string-array name="alignment_array" translatable="false">
+        <item>@string/alignement_none</item>
+        <item>@string/alignement_left</item>
+        <item>@string/alignement_center</item>
+        <item>@string/alignement_right</item>
     </string-array>
 
     <!-- Accessibility - format bar button descriptions -->


### PR DESCRIPTION
Fix #445: translated alignement issue in ImageSettings screen

Note: once this is merged in develop, this should be subtree pulled in wpandroid `release/5.8` and the strings from the editor copied to `strings.xml` in wpandroid.
