### PR TITLE
Update Travis (and example app) to API 25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ android:
     - extra-android-support
     - platform-tools
     - tools
-    - build-tools-24.0.2
-    - android-24
+    - build-tools-25.0.1
+    - android-25
 
 env:
   global:

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -14,13 +14,13 @@ repositories {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion 25
     buildToolsVersion "25.0.1"
 
     defaultConfig {
         applicationId "org.wordpress.editorexample"
         minSdkVersion 16
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Fixes failing Travis in `develop`.